### PR TITLE
Remove stray #pragma directives

### DIFF
--- a/Source/ExodusProtocol/Public/BPHelpers.h
+++ b/Source/ExodusProtocol/Public/BPHelpers.h
@@ -32,4 +32,3 @@ public:
     UFUNCTION(BlueprintCallable, Category = "Status")
     static void ApplyStatusEffect(AActor* Target, const FStatusEffectData& StatusData, int32 Stacks, int32 Duration);
 };
-#pragma once

--- a/Source/ExodusProtocol/Public/CoreGameMode.h
+++ b/Source/ExodusProtocol/Public/CoreGameMode.h
@@ -37,4 +37,3 @@ private:
     UPROPERTY()
     TObjectPtr<UEventRouter> EventRouter = nullptr;
 };
-#pragma once

--- a/Source/ExodusProtocol/Public/StatusTypes.h
+++ b/Source/ExodusProtocol/Public/StatusTypes.h
@@ -1,7 +1,5 @@
 ﻿#pragma once
 //=== StatusTypes.h ========================================================
-#pragma once
-
 #include "CoreMinimal.h"
 #include "GameplayTagContainer.h" // Remove if you won't use GameplayTags
 


### PR DESCRIPTION
## Summary
- clean up duplicate `#pragma once` usage
- fix header guards in `BPHelpers.h`, `CoreGameMode.h`, and `StatusTypes.h`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c223a573c8326a4e8bb5bc6dd6171