### PR TITLE
Normalize comment punctuation

### DIFF
--- a/Source/ExodusProtocol/ExodusProtocol.Build.cs
+++ b/Source/ExodusProtocol/ExodusProtocol.Build.cs
@@ -19,7 +19,7 @@ public class ExodusProtocol : ModuleRules
             "GameplayTags"
         });
 
-        // Add any private‑only dependencies here later
+        // Add any private-only dependencies here later
         PrivateDependencyModuleNames.AddRange(new string[] { });
 
         // Uncomment if you are using Slate UI

--- a/Source/ExodusProtocol/Private/CardTypes.cpp
+++ b/Source/ExodusProtocol/Private/CardTypes.cpp
@@ -1,2 +1,2 @@
 //=== CardTypes.cpp ========================================================
-#include "CardTypes.h" // Nothing to implement – the cpp just exists so the module compiles.
+#include "CardTypes.h" // Nothing to implement - the cpp just exists so the module compiles.

--- a/Source/ExodusProtocol/Private/CoreGameMode.cpp
+++ b/Source/ExodusProtocol/Private/CoreGameMode.cpp
@@ -18,7 +18,7 @@ void ACoreGameMode::BeginPlay()
         EventRouter = NewObject<UEventRouter>(this, EventRouterClass);
         if (EventRouter)
         {
-            EventRouter->AddToRoot(); // ensure it isn’t garbage-collected
+            EventRouter->AddToRoot(); // ensure it isn't garbage-collected
         }
     }
 }

--- a/Source/ExodusProtocol/Public/ArtifactTypes.h
+++ b/Source/ExodusProtocol/Public/ArtifactTypes.h
@@ -2,9 +2,9 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "GameplayTagContainer.h"        // Remove if you don’t plan to tag artifacts
+#include "GameplayTagContainer.h"        // Remove if you don't plan to tag artifacts
 
-#include "ArtifactTypes.generated.h"     // ← must be the last include
+#include "ArtifactTypes.generated.h"     // <- must be the last include
 
 /** How rare an artifact is when rewards are rolled. */
 UENUM(BlueprintType)
@@ -17,7 +17,7 @@ enum class EArtifactRarity : uint8
     Legendary   UMETA(DisplayName = "Legendary")
 };
 
-/** Pure‑data row for a DataTable of artifacts. No behaviour—just numbers and text. */
+/** Pure-data row for a DataTable of artifacts. No behaviour - just numbers and text. */
 USTRUCT(BlueprintType)
 struct FArtifactData : public FTableRowBase
 {
@@ -35,7 +35,7 @@ struct FArtifactData : public FTableRowBase
     UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Artifact")
     FText Description;
 
-    /** 64×64 icon used in reward and inventory screens. */
+    /** 64x64 icon used in reward and inventory screens. */
     UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Artifact")
     TObjectPtr<UTexture2D> Icon = nullptr;
 
@@ -47,7 +47,7 @@ struct FArtifactData : public FTableRowBase
     UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Artifact")
     int32 GoldValue = 50;
 
-    /** Optional gameplay tags (e.g. “Artifact.Passive.BlockBoost”). */
+    /** Optional gameplay tags (e.g. "Artifact.Passive.BlockBoost"). */
     UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Artifact")
     FGameplayTag GameplayTag;
 };

--- a/Source/ExodusProtocol/Public/BPHelpers.h
+++ b/Source/ExodusProtocol/Public/BPHelpers.h
@@ -7,7 +7,7 @@
 #include "CardTypes.h"      // access to FCardData
 #include "StatusTypes.h"    // access to FStatusEffectData
 
-#include "BPHelpers.generated.h" // ← MUST be LAST include
+#include "BPHelpers.generated.h" // <- MUST be LAST include
 
 /**
  * Static helper functions callable from any Blueprint.
@@ -26,8 +26,8 @@ public:
     static FCardData FindCardData(const UDataTable* Table, FName RowName);
 
     /**
-     * Simple utility that adds stacks & duration to a status‑effect component on Target.
-     * (Assumes you have a UStatusEffectComponent you’ll write later.)
+     * Simple utility that adds stacks & duration to a status-effect component on Target.
+     * (Assumes you have a UStatusEffectComponent you'll write later.)
      */
     UFUNCTION(BlueprintCallable, Category = "Status")
     static void ApplyStatusEffect(AActor* Target, const FStatusEffectData& StatusData, int32 Stacks, int32 Duration);

--- a/Source/ExodusProtocol/Public/CardTypes.h
+++ b/Source/ExodusProtocol/Public/CardTypes.h
@@ -4,7 +4,7 @@
 #include "CoreMinimal.h"
 #include "GameplayTagContainer.h" // Remove if you won't use GameplayTags
 
-#include "CardTypes.generated.h" // ← Must be the LAST include in this header
+#include "CardTypes.generated.h" // <- Must be the LAST include in this header
 
 /**
  * Classification for rules & UI.
@@ -30,7 +30,7 @@ enum class ECardRarity : uint8
 };
 
 /**
- * Pure‑data definition of a card.  No behaviour here—only the numbers and identifiers that
+ * Pure-data definition of a card.  No behaviour here - only the numbers and identifiers that
  * designers tune in the editor.
  */
 USTRUCT(BlueprintType)
@@ -38,7 +38,7 @@ struct FCardData
 {
     GENERATED_BODY()
 
-    /** Internal name for look‑ups (e.g. "Strike_Red"). */
+    /** Internal name for look-ups (e.g. "Strike_Red"). */
     UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Card")
     FName CardID = NAME_None;
 
@@ -54,19 +54,19 @@ struct FCardData
     UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Card")
     ECardType CardType = ECardType::Attack;
 
-    /** Drop‑rate bucket for rewards. */
+    /** Drop-rate bucket for rewards. */
     UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Card")
     ECardRarity Rarity = ECardRarity::Common;
 
-    /** Energy cost shown in the top‑left pip. */
+    /** Energy cost shown in the top-left pip. */
     UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Card")
     int32 EnergyCost = 1;
 
-    /** Number fed into damage formulas; 0 for non‑damage cards. */
+    /** Number fed into damage formulas; 0 for non-damage cards. */
     UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Card")
     int32 BaseDamage = 0;
 
-    /** Number fed into block formulas; 0 for non‑block cards. */
+    /** Number fed into block formulas; 0 for non-block cards. */
     UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Card")
     int32 BaseBlock = 0;
 

--- a/Source/ExodusProtocol/Public/CoreGameMode.h
+++ b/Source/ExodusProtocol/Public/CoreGameMode.h
@@ -4,7 +4,7 @@
 #include "CoreMinimal.h"
 #include "GameFramework/GameModeBase.h"
 
-#include "CoreGameMode.generated.h" // ← Must be the LAST include
+#include "CoreGameMode.generated.h" // <- Must be the LAST include
 
 class UEventRouter;
 
@@ -21,7 +21,7 @@ class ACoreGameMode : public AGameModeBase
 public:
     ACoreGameMode();
 
-    /** Blueprint‑exposed getter */
+    /** Blueprint-exposed getter */
     UFUNCTION(BlueprintPure, Category = "Managers")
     FORCEINLINE UEventRouter* GetEventRouter() const { return EventRouter; }
 

--- a/Source/ExodusProtocol/Public/EncounterNodeTypes.h
+++ b/Source/ExodusProtocol/Public/EncounterNodeTypes.h
@@ -17,13 +17,13 @@ enum class ENodeType : uint8
     Rest       UMETA(DisplayName = "Rest Site")
 };
 
-/** Pure‑data row for the world‑map nodes. */
+/** Pure-data row for the world-map nodes. */
 USTRUCT(BlueprintType)
 struct FEncounterNodeData : public FTableRowBase
 {
     GENERATED_BODY()
 
-    /** Internal key (e.g. “Act1_Grunt”). */
+    /** Internal key (e.g. "Act1_Grunt"). */
     UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Node")
     FName NodeID = NAME_None;
 
@@ -35,11 +35,11 @@ struct FEncounterNodeData : public FTableRowBase
     UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Node")
     ENodeType NodeType = ENodeType::Combat;
 
-    /** Points to another DataTable row (enemy group, shop list, story entry…). */
+    /** Points to another DataTable row (enemy group, shop list, story entry...). */
     UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Node")
     FName PayloadID = NAME_None;
 
-    /** Extra flag for map‑generation (“Early”, “Late”, etc.). */
+    /** Extra flag for map-generation ("Early", "Late", etc.). */
     UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Node")
     FGameplayTag NodeTag;
 };

--- a/Source/ExodusProtocol/Public/EventRouter.h
+++ b/Source/ExodusProtocol/Public/EventRouter.h
@@ -6,7 +6,7 @@
     the delegate macros can see FCardData           */
 #include "CardTypes.h"         
 
-#include "EventRouter.generated.h"   // ← absolutely last include
+#include "EventRouter.generated.h"   // <- absolutely last include
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FCardPlayedEvent,
     const FCardData&, CardData);

--- a/Source/ExodusProtocol/Public/StatusTypes.h
+++ b/Source/ExodusProtocol/Public/StatusTypes.h
@@ -3,7 +3,7 @@
 #include "CoreMinimal.h"
 #include "GameplayTagContainer.h" // Remove if you won't use GameplayTags
 
-#include "StatusTypes.generated.h" // ← Must be the LAST include in this header
+#include "StatusTypes.generated.h" // <- Must be the LAST include in this header
 
 /**
  * Broad grouping used by UI (green vs. red) and balance logic.
@@ -21,7 +21,7 @@ enum class EStatusCategory : uint8
 UENUM(BlueprintType)
 enum class EStatusStacking : uint8
 {
-    /** Adds its stacks on top of what’s already there. */
+    /** Adds its stacks on top of what's already there. */
     Stack       UMETA(DisplayName = "Stack"),
 
     /** Resets the remaining duration but keeps current stacks. */
@@ -32,7 +32,7 @@ enum class EStatusStacking : uint8
 };
 
 /**
- * Pure‑data description of a status effect (Bleed, Strength, Vulnerable…).
+ * Pure-data description of a status effect (Bleed, Strength, Vulnerable...).
  * Designers tweak these in DataTables / PrimaryDataAssets.
  */
 USTRUCT(BlueprintType)
@@ -40,7 +40,7 @@ struct FStatusEffectData
 {
     GENERATED_BODY()
 
-    /** Internal ID for look‑ups (e.g. "Bleed"). */
+    /** Internal ID for look-ups (e.g. "Bleed"). */
     UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Status")
     FName StatusID = NAME_None;
 
@@ -48,11 +48,11 @@ struct FStatusEffectData
     UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Status")
     FText DisplayName;
 
-    /** 32×32 or 64×64 icon used in the HUD. */
+    /** 32x32 or 64x64 icon used in the HUD. */
     UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Status")
     TObjectPtr<UTexture2D> Icon = nullptr;
 
-    /** Buff vs. Debuff for colour‑coding and certain rules. */
+    /** Buff vs. Debuff for colour-coding and certain rules. */
     UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Status")
     EStatusCategory Category = EStatusCategory::Debuff;
 


### PR DESCRIPTION
## Summary
- fix non-ASCII punctuation in comments across C++ headers and sources

## Testing
- `python3 - <<'EOF'
import os
paths=[]
for root,dirs,files in os.walk('Source'):
    for f in files:
        fp=os.path.join(root,f)
        if any(b>127 for b in open(fp,'rb').read()):
            paths.append(fp)
print(paths)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_686c233f3e108326b6925b0f4083d02b