### PR TITLE
Implement data tables for Decks, Minions and Patterns

### DIFF
--- a/Source/ExodusProtocol/ExodusProtocol.Build.cs
+++ b/Source/ExodusProtocol/ExodusProtocol.Build.cs
@@ -16,11 +16,12 @@ public class ExodusProtocol : ModuleRules
             "Engine",
             "InputCore",
             "EnhancedInput",
-            "GameplayTags"
+            "GameplayTags",
+            "UMG"
         });
 
         // Add any private‑only dependencies here later
-        PrivateDependencyModuleNames.AddRange(new string[] { });
+        PrivateDependencyModuleNames.AddRange(new string[] { "Slate", "SlateCore" });
 
         // Uncomment if you are using Slate UI
         // PrivateDependencyModuleNames.AddRange(new string[] { "Slate", "SlateCore" });

--- a/Source/ExodusProtocol/Private/CardPatternTypes.cpp
+++ b/Source/ExodusProtocol/Private/CardPatternTypes.cpp
@@ -1,0 +1,1 @@
+#include "CardPatternTypes.h"

--- a/Source/ExodusProtocol/Private/DeckTypes.cpp
+++ b/Source/ExodusProtocol/Private/DeckTypes.cpp
@@ -1,0 +1,1 @@
+#include "DeckTypes.h"

--- a/Source/ExodusProtocol/Private/MinionTypes.cpp
+++ b/Source/ExodusProtocol/Private/MinionTypes.cpp
@@ -1,0 +1,1 @@
+#include "MinionTypes.h"

--- a/Source/ExodusProtocol/Public/CardPatternTypes.h
+++ b/Source/ExodusProtocol/Public/CardPatternTypes.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameplayTagContainer.h"
+#include "Engine/DataTable.h"
+
+#include "CardPatternTypes.generated.h"
+
+/** Row describing how AI chooses cards to play. */
+USTRUCT(BlueprintType)
+struct FCardPatternData : public FTableRowBase
+{
+    GENERATED_BODY();
+
+    /** Card to play. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Pattern")
+    FName CardID = NAME_None;
+
+    /** Weight used for random selection. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Pattern")
+    int32 Weight = 1;
+
+    /** How many times this card can be repeated in a row. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Pattern")
+    int32 RepeatLimit = 0;
+
+    /** Optional tag for conditional logic. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Pattern")
+    FGameplayTag PatternTag;
+};
+

--- a/Source/ExodusProtocol/Public/CardTypes.h
+++ b/Source/ExodusProtocol/Public/CardTypes.h
@@ -3,6 +3,7 @@
 
 #include "CoreMinimal.h"
 #include "GameplayTagContainer.h" // Remove if you won't use GameplayTags
+#include "Blueprint/UserWidget.h" // for CardVisualWidget
 
 #include "CardTypes.generated.h" // ← Must be the LAST include in this header
 
@@ -50,6 +51,18 @@ struct FCardData
     UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Card")
     TObjectPtr<UTexture2D> Portrait = nullptr;
 
+    /** Card frame backing image. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Card|Visual")
+    TObjectPtr<UTexture2D> Frame = nullptr;
+
+    /** Tint applied to the frame texture. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Card|Visual")
+    FLinearColor FrameTint = FLinearColor::White;
+
+    /** Optional widget class used for the in-hand visual. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Card|Visual")
+    TSubclassOf<UUserWidget> CardVisualWidget;
+
     /** Broad gameplay bucket (Attack, Skill, etc.). */
     UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Card")
     ECardType CardType = ECardType::Attack;
@@ -73,4 +86,12 @@ struct FCardData
     /** Tags of status effects this card applies when it resolves. */
     UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Card")
     TArray<FGameplayTag> GrantedStatusEffects;
+
+    /** Status effects automatically present when the card is drawn. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Card")
+    TArray<FGameplayTag> StartingStatuses;
+
+    /** How many times the card's effect repeats. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Card")
+    int32 Repetitions = 1;
 };

--- a/Source/ExodusProtocol/Public/DeckTypes.h
+++ b/Source/ExodusProtocol/Public/DeckTypes.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameplayTagContainer.h"
+#include "Engine/DataTable.h"
+
+#include "DeckTypes.generated.h"
+
+/** Data describing a starter or enemy deck. */
+USTRUCT(BlueprintType)
+struct FDeckData : public FTableRowBase
+{
+    GENERATED_BODY();
+
+    /** Internal row name / ID. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Deck")
+    FName DeckID = NAME_None;
+
+    /** Cards included in this deck by ID. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Deck")
+    TArray<FName> CardIDs;
+};
+

--- a/Source/ExodusProtocol/Public/MinionTypes.h
+++ b/Source/ExodusProtocol/Public/MinionTypes.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameplayTagContainer.h"
+#include "Engine/DataTable.h"
+
+#include "MinionTypes.generated.h"
+
+/** Data for an enemy or ally minion. */
+USTRUCT(BlueprintType)
+struct FMinionData : public FTableRowBase
+{
+    GENERATED_BODY();
+
+    /** Row identifier. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Minion")
+    FName MinionID = NAME_None;
+
+    /** Display name shown on UI. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Minion")
+    FText DisplayName;
+
+    /** Mesh or visual asset for spawning. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Minion")
+    TObjectPtr<USkeletalMesh> Mesh = nullptr;
+
+    /** Deck row this minion draws cards from. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Minion")
+    FName DeckID = NAME_None;
+
+    /** Optional attack pattern row used by AI. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Minion")
+    FName AttackPatternID = NAME_None;
+};
+


### PR DESCRIPTION
## Summary
- extend `FCardData` with extra visual and rules data
- add new structs `FDeckData`, `FMinionData`, `FCardPatternData`
- create matching stub cpp files
- enable UMG in build rules so card widget references compile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c25d96e4c832699f150297f811e43