### PR TITLE
Implement component-driven actors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # 🃏 Unreal Engine 5.6 Card-Battler – Blueprint Framework
 
-### 📈 Progress  **2 / 16 steps complete (≈ 12 %)**
+### 📈 Progress  **3 / 16 steps complete (≈ 19 %)**
 
 | ✔ | # | 🎯 Goal | 🔑 Blueprint / Asset Types | 🧩 What You Build |
 |:-:|---|---------|---------------------------|------------------|
 | ✅ | 0 | **Clean project** | Blank **C++** template, single **BP_/** folder | Turn on *Enhanced Input*, *Data Assets*, *Gameplay Tags*, *SaveGame* in **Plugins**. <br/>*Docs → Project Setup, Plugins* |
 | ✅ | 1 | **Pure data first** | `UStruct`, `DataTable`, `PrimaryDataAsset` | `FCardData`, `FStatusEffectData`, `FArtifactData`, `FEncounterNodeData` – fields only, no logic. Easy tuning & CSV import. <br/>*Docs → UStructs & Data Tables* |
-| ⬜ | 2 | **Component actors** | `UCardComponent`, `UStatusEffectComponent`, `UAttackPatternComponent`, `UCombatStatsComponent` | Build pawns/enemies/cards by stacking components → reusable & testable. <br/>*Docs → Actor Components* |
+| ✅ | 2 | **Component actors** | `UCardComponent`, `UStatusEffectComponent`, `UAttackPatternComponent`, `UCombatStatsComponent` | Build pawns/enemies/cards by stacking components → reusable & testable. <br/>*Docs → Actor Components* |
 | ⬜ | 3 | **Card lifecycle** | `BP_CardActor` (world) + `BP_CardWidget` (UI) | States: *DrawPile → Hand → Queue → Grave*. Fire events: `OnDraw`, `OnPlay`, `OnResolve`, `OnDiscard`. <br/>*Docs → Gameplay Framework* |
 | ⬜ | 4 | **Turn manager** | `BP_CombatManager` | Controls loop: *StartTurn → Player → Enemy → EndTurn*. Tracks rounds, energy, win/loss. <br/>*Docs → Timers & Tick* |
 | ⬜ | 5 | **Event bus** | `BP_EventRouter` (on GameInstance) **or** Blueprint Interface | Publish/Subscribe: e.g. `"CardPlayed"`, `"DamageTaken"`; loose coupling. <br/>*Docs → Blueprint Dispatchers* |

--- a/Source/ExodusProtocol/ExodusProtocol.Build.cs
+++ b/Source/ExodusProtocol/ExodusProtocol.Build.cs
@@ -16,11 +16,12 @@ public class ExodusProtocol : ModuleRules
             "Engine",
             "InputCore",
             "EnhancedInput",
-            "GameplayTags"
+            "GameplayTags",
+            "UMG"
         });
 
         // Add any private‑only dependencies here later
-        PrivateDependencyModuleNames.AddRange(new string[] { });
+        PrivateDependencyModuleNames.AddRange(new string[] { "Slate", "SlateCore" });
 
         // Uncomment if you are using Slate UI
         // PrivateDependencyModuleNames.AddRange(new string[] { "Slate", "SlateCore" });

--- a/Source/ExodusProtocol/Private/AttackPatternComponent.cpp
+++ b/Source/ExodusProtocol/Private/AttackPatternComponent.cpp
@@ -1,0 +1,27 @@
+//=== AttackPatternComponent.cpp ===========================================
+#include "AttackPatternComponent.h"
+
+#include "Engine/DataTable.h"
+
+UAttackPatternComponent::UAttackPatternComponent()
+{
+    PrimaryComponentTick.bCanEverTick = false;
+}
+
+FCardPatternData UAttackPatternComponent::ChooseNextPattern() const
+{
+    if (!PatternTable)
+    {
+        return FCardPatternData();
+    }
+
+    const TArray<FName> RowNames = PatternTable->GetRowNames();
+    if (RowNames.Num() > 0)
+    {
+        if (const FCardPatternData* Row = PatternTable->FindRow<FCardPatternData>(RowNames[0], TEXT("ChooseNextPattern")))
+        {
+            return *Row;
+        }
+    }
+    return FCardPatternData();
+}

--- a/Source/ExodusProtocol/Private/CardComponent.cpp
+++ b/Source/ExodusProtocol/Private/CardComponent.cpp
@@ -1,0 +1,22 @@
+//=== CardComponent.cpp =====================================================
+#include "CardComponent.h"
+
+#include "GameFramework/Actor.h"
+
+UCardComponent::UCardComponent()
+{
+    PrimaryComponentTick.bCanEverTick = false;
+}
+
+void UCardComponent::SetCardData(const FCardData& Data)
+{
+    CardData = Data;
+}
+
+void UCardComponent::PlayCard()
+{
+    if (UEventRouter* Router = UEventRouter::Get(this))
+    {
+        Router->OnCardPlayed.Broadcast(CardData);
+    }
+}

--- a/Source/ExodusProtocol/Private/CardPatternTypes.cpp
+++ b/Source/ExodusProtocol/Private/CardPatternTypes.cpp
@@ -1,0 +1,1 @@
+#include "CardPatternTypes.h"

--- a/Source/ExodusProtocol/Private/CombatStatsComponent.cpp
+++ b/Source/ExodusProtocol/Private/CombatStatsComponent.cpp
@@ -1,0 +1,24 @@
+//=== CombatStatsComponent.cpp =============================================
+#include "CombatStatsComponent.h"
+
+#include "GameFramework/Actor.h"
+
+UCombatStatsComponent::UCombatStatsComponent()
+{
+    PrimaryComponentTick.bCanEverTick = false;
+}
+
+void UCombatStatsComponent::BeginPlay()
+{
+    Super::BeginPlay();
+    CurrentHealth = MaxHealth;
+}
+
+void UCombatStatsComponent::TakeDamage(int32 Amount)
+{
+    CurrentHealth = FMath::Clamp(CurrentHealth - Amount, 0, MaxHealth);
+    if (UEventRouter* Router = UEventRouter::Get(this))
+    {
+        Router->OnDamageTaken.Broadcast(GetOwner(), Amount);
+    }
+}

--- a/Source/ExodusProtocol/Private/DeckTypes.cpp
+++ b/Source/ExodusProtocol/Private/DeckTypes.cpp
@@ -1,0 +1,1 @@
+#include "DeckTypes.h"

--- a/Source/ExodusProtocol/Private/MinionTypes.cpp
+++ b/Source/ExodusProtocol/Private/MinionTypes.cpp
@@ -1,0 +1,1 @@
+#include "MinionTypes.h"

--- a/Source/ExodusProtocol/Private/StatusEffectComponent.cpp
+++ b/Source/ExodusProtocol/Private/StatusEffectComponent.cpp
@@ -1,0 +1,16 @@
+//=== StatusEffectComponent.cpp ============================================
+#include "StatusEffectComponent.h"
+
+UStatusEffectComponent::UStatusEffectComponent()
+{
+    PrimaryComponentTick.bCanEverTick = false;
+}
+
+void UStatusEffectComponent::AddStatus(const FStatusEffectData& Data, int32 Stacks, int32 Duration)
+{
+    FActiveStatus NewStatus;
+    NewStatus.Data = Data;
+    NewStatus.Stacks = Stacks;
+    NewStatus.Duration = Duration;
+    ActiveEffects.Add(NewStatus);
+}

--- a/Source/ExodusProtocol/Public/AttackPatternComponent.h
+++ b/Source/ExodusProtocol/Public/AttackPatternComponent.h
@@ -1,0 +1,27 @@
+//=== AttackPatternComponent.h =============================================
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "Engine/DataTable.h"
+
+#include "CardPatternTypes.h"
+
+#include "AttackPatternComponent.generated.h"
+
+/** AI helper that chooses which card an enemy will play next. */
+UCLASS(ClassGroup=(AI), meta=(BlueprintSpawnableComponent))
+class UAttackPatternComponent : public UActorComponent
+{
+    GENERATED_BODY()
+public:
+    UAttackPatternComponent();
+
+    /** DataTable defining possible actions. */
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="AI")
+    TObjectPtr<UDataTable> PatternTable = nullptr;
+
+    /** Pick the next pattern row (placeholder logic). */
+    UFUNCTION(BlueprintCallable, Category="AI")
+    FCardPatternData ChooseNextPattern() const;
+};

--- a/Source/ExodusProtocol/Public/CardComponent.h
+++ b/Source/ExodusProtocol/Public/CardComponent.h
@@ -1,0 +1,31 @@
+//=== CardComponent.h ======================================================
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+
+#include "CardTypes.h"
+#include "EventRouter.h"
+
+#include "CardComponent.generated.h"
+
+/** Component that stores data for an individual card instance. */
+UCLASS(ClassGroup=(Card), meta=(BlueprintSpawnableComponent))
+class UCardComponent : public UActorComponent
+{
+    GENERATED_BODY()
+public:
+    UCardComponent();
+
+    /** Data describing this card. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Card")
+    FCardData CardData;
+
+    /** Assign new card data at runtime. */
+    UFUNCTION(BlueprintCallable, Category="Card")
+    void SetCardData(const FCardData& Data);
+
+    /** Broadcasts OnCardPlayed via the global event router. */
+    UFUNCTION(BlueprintCallable, Category="Card")
+    void PlayCard();
+};

--- a/Source/ExodusProtocol/Public/CardPatternTypes.h
+++ b/Source/ExodusProtocol/Public/CardPatternTypes.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameplayTagContainer.h"
+#include "Engine/DataTable.h"
+
+#include "CardPatternTypes.generated.h"
+
+/** Row describing how AI chooses cards to play. */
+USTRUCT(BlueprintType)
+struct FCardPatternData : public FTableRowBase
+{
+    GENERATED_BODY();
+
+    /** Card to play. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Pattern")
+    FName CardID = NAME_None;
+
+    /** Weight used for random selection. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Pattern")
+    int32 Weight = 1;
+
+    /** How many times this card can be repeated in a row. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Pattern")
+    int32 RepeatLimit = 0;
+
+    /** Optional tag for conditional logic. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Pattern")
+    FGameplayTag PatternTag;
+};
+

--- a/Source/ExodusProtocol/Public/CardTypes.h
+++ b/Source/ExodusProtocol/Public/CardTypes.h
@@ -3,6 +3,7 @@
 
 #include "CoreMinimal.h"
 #include "GameplayTagContainer.h" // Remove if you won't use GameplayTags
+#include "Blueprint/UserWidget.h" // for CardVisualWidget
 
 #include "CardTypes.generated.h" // ← Must be the LAST include in this header
 
@@ -50,6 +51,18 @@ struct FCardData
     UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Card")
     TObjectPtr<UTexture2D> Portrait = nullptr;
 
+    /** Card frame backing image. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Card|Visual")
+    TObjectPtr<UTexture2D> Frame = nullptr;
+
+    /** Tint applied to the frame texture. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Card|Visual")
+    FLinearColor FrameTint = FLinearColor::White;
+
+    /** Optional widget class used for the in-hand visual. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Card|Visual")
+    TSubclassOf<UUserWidget> CardVisualWidget;
+
     /** Broad gameplay bucket (Attack, Skill, etc.). */
     UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Card")
     ECardType CardType = ECardType::Attack;
@@ -73,4 +86,12 @@ struct FCardData
     /** Tags of status effects this card applies when it resolves. */
     UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Card")
     TArray<FGameplayTag> GrantedStatusEffects;
+
+    /** Status effects automatically present when the card is drawn. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Card")
+    TArray<FGameplayTag> StartingStatuses;
+
+    /** How many times the card's effect repeats. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Card")
+    int32 Repetitions = 1;
 };

--- a/Source/ExodusProtocol/Public/CombatStatsComponent.h
+++ b/Source/ExodusProtocol/Public/CombatStatsComponent.h
@@ -1,0 +1,32 @@
+//=== CombatStatsComponent.h ===============================================
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+
+#include "EventRouter.h"
+
+#include "CombatStatsComponent.generated.h"
+
+/** Health and other core combat numbers. */
+UCLASS(ClassGroup=(Combat), meta=(BlueprintSpawnableComponent))
+class UCombatStatsComponent : public UActorComponent
+{
+    GENERATED_BODY()
+public:
+    UCombatStatsComponent();
+
+    /** Maximum hit points. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Stats")
+    int32 MaxHealth = 100;
+
+    /** Current hit points. */
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="Stats")
+    int32 CurrentHealth = 0;
+
+    virtual void BeginPlay() override;
+
+    /** Lose HP and broadcast to event router. */
+    UFUNCTION(BlueprintCallable, Category="Stats")
+    void TakeDamage(int32 Amount);
+};

--- a/Source/ExodusProtocol/Public/DeckTypes.h
+++ b/Source/ExodusProtocol/Public/DeckTypes.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameplayTagContainer.h"
+#include "Engine/DataTable.h"
+
+#include "DeckTypes.generated.h"
+
+/** Data describing a starter or enemy deck. */
+USTRUCT(BlueprintType)
+struct FDeckData : public FTableRowBase
+{
+    GENERATED_BODY();
+
+    /** Internal row name / ID. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Deck")
+    FName DeckID = NAME_None;
+
+    /** Cards included in this deck by ID. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Deck")
+    TArray<FName> CardIDs;
+};
+

--- a/Source/ExodusProtocol/Public/MinionTypes.h
+++ b/Source/ExodusProtocol/Public/MinionTypes.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameplayTagContainer.h"
+#include "Engine/DataTable.h"
+
+#include "MinionTypes.generated.h"
+
+/** Data for an enemy or ally minion. */
+USTRUCT(BlueprintType)
+struct FMinionData : public FTableRowBase
+{
+    GENERATED_BODY();
+
+    /** Row identifier. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Minion")
+    FName MinionID = NAME_None;
+
+    /** Display name shown on UI. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Minion")
+    FText DisplayName;
+
+    /** Mesh or visual asset for spawning. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Minion")
+    TObjectPtr<USkeletalMesh> Mesh = nullptr;
+
+    /** Deck row this minion draws cards from. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Minion")
+    FName DeckID = NAME_None;
+
+    /** Optional attack pattern row used by AI. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Minion")
+    FName AttackPatternID = NAME_None;
+};
+

--- a/Source/ExodusProtocol/Public/StatusEffectComponent.h
+++ b/Source/ExodusProtocol/Public/StatusEffectComponent.h
@@ -1,0 +1,42 @@
+//=== StatusEffectComponent.h ==============================================
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+
+#include "StatusTypes.h"
+
+#include "StatusEffectComponent.generated.h"
+
+/** Individual stack of an effect currently applied to the owner. */
+USTRUCT(BlueprintType)
+struct FActiveStatus
+{
+    GENERATED_BODY()
+
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="Status")
+    FStatusEffectData Data;
+
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="Status")
+    int32 Stacks = 0;
+
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="Status")
+    int32 Duration = 0;
+};
+
+/** Component tracking status effects like Poison or Strength. */
+UCLASS(ClassGroup=(Status), meta=(BlueprintSpawnableComponent))
+class UStatusEffectComponent : public UActorComponent
+{
+    GENERATED_BODY()
+public:
+    UStatusEffectComponent();
+
+    /** Current effects on this actor. */
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="Status")
+    TArray<FActiveStatus> ActiveEffects;
+
+    /** Simple adder that ignores stacking rules for now. */
+    UFUNCTION(BlueprintCallable, Category="Status")
+    void AddStatus(const FStatusEffectData& Data, int32 Stacks, int32 Duration);
+};


### PR DESCRIPTION
## Summary
- track progress in README
- introduce core actor components: card, status, attack pattern and combat stats
- send events through `UEventRouter`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686c25d96e4c832699f150297f811e43