### PR TITLE
Add gameplay actor components

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 | ✅ | 0 | **Clean project** | Blank **C++** template, single **BP_/** folder | Turn on *Enhanced Input*, *Data Assets*, *Gameplay Tags*, *SaveGame* in **Plugins**. <br/>*Docs → Project Setup, Plugins* |
 | ✅ | 1 | **Pure data first** | `UStruct`, `DataTable`, `PrimaryDataAsset` | `FCardData`, `FStatusEffectData`, `FArtifactData`, `FEncounterNodeData` – fields only, no logic. Easy tuning & CSV import. <br/>*Docs → UStructs & Data Tables* |
 | ⬜ | 2 | **Component actors** | `UCardComponent`, `UStatusEffectComponent`, `UAttackPatternComponent`, `UCombatStatsComponent` | Build pawns/enemies/cards by stacking components → reusable & testable. <br/>*Docs → Actor Components* |
+
 | ⬜ | 3 | **Card lifecycle** | `BP_CardActor` (world) + `BP_CardWidget` (UI) | States: *DrawPile → Hand → Queue → Grave*. Fire events: `OnDraw`, `OnPlay`, `OnResolve`, `OnDiscard`. <br/>*Docs → Gameplay Framework* |
 | ⬜ | 4 | **Turn manager** | `BP_CombatManager` | Controls loop: *StartTurn → Player → Enemy → EndTurn*. Tracks rounds, energy, win/loss. <br/>*Docs → Timers & Tick* |
 | ⬜ | 5 | **Event bus** | `BP_EventRouter` (on GameInstance) **or** Blueprint Interface | Publish/Subscribe: e.g. `"CardPlayed"`, `"DamageTaken"`; loose coupling. <br/>*Docs → Blueprint Dispatchers* |
@@ -20,6 +21,13 @@
 | ⬜ | 13 | **Example content** | CSV → DataTable import | Add 20 cards, 5 artifacts, 3 status effects per rarity. Use public-domain art. <br/>*Docs → Data Import* |
 | ⬜ | 14 | **QA & balance** | Editor Utility Widget “BalanceBoard” | Show live stats: dmg/energy, draw odds. Tweak numbers directly in DataTables. <br/>*Docs → Editor Utility Widgets* |
 | ⬜ | 15 | **Package & hand-off** | Project Settings → Packaging | Check cooked assets, size, redirects. Ship this README so new folks can jump in anywhere. <br/>*Docs → Packaging Projects* |
+
+## Using the New Components
+
+* **UCardComponent** – attach to card actors and trigger the dispatcher events when the card is drawn or played.
+* **UStatusEffectComponent** – keeps active effects; call `ApplyStatus` or `ApplyStatusByTag` to add stacks.
+* **UAttackPatternComponent** – link a DataTable of `FCardPatternData` and call `PickNextCard()` for weighted AI.
+* **UCombatStatsComponent** – stores health, block and energy. `ApplyDamage()` notifies the global `UEventRouter`.
 
 ---
 

--- a/Source/ExodusProtocol/Private/AttackPatternComponent.cpp
+++ b/Source/ExodusProtocol/Private/AttackPatternComponent.cpp
@@ -1,0 +1,65 @@
+#include "AttackPatternComponent.h"
+#include "Engine/DataTable.h"
+
+UAttackPatternComponent::UAttackPatternComponent()
+{
+    PrimaryComponentTick.bCanEverTick = false;
+}
+
+void UAttackPatternComponent::BeginPlay()
+{
+    Super::BeginPlay();
+}
+
+FName UAttackPatternComponent::PickNextCard()
+{
+    if (!PatternTable)
+    {
+        return NAME_None;
+    }
+
+    TArray<FCardPatternData*> Rows;
+    PatternTable->GetAllRows<FCardPatternData>(TEXT("PickNextCard"), Rows);
+    if (Rows.Num() == 0)
+    {
+        return NAME_None;
+    }
+
+    TArray<const FCardPatternData*> ValidRows;
+    int32 TotalWeight = 0;
+    for (const FCardPatternData* Row : Rows)
+    {
+        if (Row->RepeatLimit > 0 && LastCard == Row->CardID && RepeatCount >= Row->RepeatLimit)
+        {
+            continue;
+        }
+        ValidRows.Add(Row);
+        TotalWeight += FMath::Max(1, Row->Weight);
+    }
+
+    if (ValidRows.Num() == 0)
+    {
+        return NAME_None;
+    }
+
+    int32 Roll = FMath::RandRange(1, TotalWeight);
+    for (const FCardPatternData* Row : ValidRows)
+    {
+        Roll -= FMath::Max(1, Row->Weight);
+        if (Roll <= 0)
+        {
+            if (LastCard == Row->CardID)
+            {
+                ++RepeatCount;
+            }
+            else
+            {
+                LastCard = Row->CardID;
+                RepeatCount = 1;
+            }
+            return Row->CardID;
+        }
+    }
+
+    return NAME_None;
+}

--- a/Source/ExodusProtocol/Private/BPHelpers.cpp
+++ b/Source/ExodusProtocol/Private/BPHelpers.cpp
@@ -2,6 +2,7 @@
 #include "BPHelpers.h"
 #include "Engine/DataTable.h"
 #include "GameFramework/Actor.h"
+#include "StatusEffectComponent.h"
 
 FCardData UBPHelpers::FindCardData(const UDataTable* Table, FName RowName)
 {
@@ -14,7 +15,8 @@ void UBPHelpers::ApplyStatusEffect(AActor* Target, const FStatusEffectData& Stat
 {
     if (!Target) { return; }
 
-    // Placeholder: you will replace this with real component logic.
-    UE_LOG(LogTemp, Verbose, TEXT("ApplyStatusEffect %s to %s: %d stacks for %d turns"),
-        *StatusData.StatusID.ToString(), *Target->GetName(), Stacks, Duration);
+    if (UStatusEffectComponent* StatusComp = Target->FindComponentByClass<UStatusEffectComponent>())
+    {
+        StatusComp->ApplyStatus(StatusData, Stacks, Duration);
+    }
 }

--- a/Source/ExodusProtocol/Private/CardComponent.cpp
+++ b/Source/ExodusProtocol/Private/CardComponent.cpp
@@ -1,0 +1,40 @@
+#include "CardComponent.h"
+#include "StatusEffectComponent.h"
+
+UCardComponent::UCardComponent()
+{
+    PrimaryComponentTick.bCanEverTick = false;
+}
+
+void UCardComponent::BeginPlay()
+{
+    Super::BeginPlay();
+
+    if (UStatusEffectComponent* StatusComp = GetOwner()->FindComponentByClass<UStatusEffectComponent>())
+    {
+        for (const FGameplayTag& Tag : CardData.StartingStatuses)
+        {
+            StatusComp->ApplyStatusByTag(Tag, 0, 0);
+        }
+    }
+}
+
+void UCardComponent::TriggerDraw()
+{
+    OnDraw.Broadcast();
+}
+
+void UCardComponent::TriggerPlay()
+{
+    OnPlay.Broadcast();
+}
+
+void UCardComponent::TriggerResolve()
+{
+    OnResolve.Broadcast();
+}
+
+void UCardComponent::TriggerDiscard()
+{
+    OnDiscard.Broadcast();
+}

--- a/Source/ExodusProtocol/Private/CombatStatsComponent.cpp
+++ b/Source/ExodusProtocol/Private/CombatStatsComponent.cpp
@@ -1,0 +1,45 @@
+#include "CombatStatsComponent.h"
+#include "EventRouter.h"
+
+UCombatStatsComponent::UCombatStatsComponent()
+{
+    PrimaryComponentTick.bCanEverTick = false;
+}
+
+void UCombatStatsComponent::ApplyDamage(int32 Amount)
+{
+    if (Amount <= 0 || bIsDead)
+    {
+        return;
+    }
+
+    int32 InitialAmount = Amount;
+    int32 Absorbed = FMath::Min(Block, Amount);
+    Block -= Absorbed;
+    Amount -= Absorbed;
+
+    if (Amount > 0)
+    {
+        Health -= Amount;
+    }
+
+    if (UEventRouter* Router = UEventRouter::Get(this))
+    {
+        Router->OnDamageTaken.Broadcast(GetOwner(), InitialAmount);
+        if (Health <= 0 && !bIsDead)
+        {
+            bIsDead = true;
+            Router->OnActorDied.Broadcast(GetOwner());
+        }
+    }
+}
+
+void UCombatStatsComponent::AddBlock(int32 Amount)
+{
+    Block += Amount;
+}
+
+void UCombatStatsComponent::AddEnergy(int32 Amount)
+{
+    Energy += Amount;
+}

--- a/Source/ExodusProtocol/Private/StatusEffectComponent.cpp
+++ b/Source/ExodusProtocol/Private/StatusEffectComponent.cpp
@@ -1,0 +1,86 @@
+#include "StatusEffectComponent.h"
+#include "Engine/DataTable.h"
+
+UStatusEffectComponent::UStatusEffectComponent()
+{
+    PrimaryComponentTick.bCanEverTick = true;
+}
+
+void UStatusEffectComponent::BeginPlay()
+{
+    Super::BeginPlay();
+}
+
+void UStatusEffectComponent::ApplyStatus(const FStatusEffectData& Data, int32 Stacks, int32 Duration)
+{
+    if (Data.StatusID.IsNone()) { return; }
+    const int32 StackValue = Stacks > 0 ? Stacks : Data.BaseStacks;
+    const int32 DurationValue = Duration > 0 ? Duration : Data.BaseDuration;
+
+    if (FActiveStatusEffect* Existing = ActiveEffects.FindByPredicate([&](const FActiveStatusEffect& E){ return E.StatusID == Data.StatusID; }))
+    {
+        switch (Data.Stacking)
+        {
+            case EStatusStacking::Stack:
+                Existing->Stacks += StackValue;
+                Existing->Duration = FMath::Max(Existing->Duration, DurationValue);
+                break;
+            case EStatusStacking::Refresh:
+                Existing->Duration = DurationValue;
+                break;
+            case EStatusStacking::Replace:
+                Existing->Stacks = StackValue;
+                Existing->Duration = DurationValue;
+                break;
+        }
+    }
+    else
+    {
+        FActiveStatusEffect NewEffect;
+        NewEffect.StatusID = Data.StatusID;
+        NewEffect.Stacks = StackValue;
+        NewEffect.Duration = DurationValue;
+        ActiveEffects.Add(NewEffect);
+    }
+}
+
+void UStatusEffectComponent::ApplyStatusByTag(FGameplayTag StatusTag, int32 Stacks, int32 Duration)
+{
+    if (!StatusDataTable || !StatusTag.IsValid()) { return; }
+
+    TArray<FName> RowNames = StatusDataTable->GetRowNames();
+    for (const FName& RowName : RowNames)
+    {
+        const FStatusEffectData* Row = StatusDataTable->FindRow<FStatusEffectData>(RowName, TEXT("ApplyStatusByTag"));
+        if (Row && Row->GameplayTag == StatusTag)
+        {
+            ApplyStatus(*Row, Stacks, Duration);
+            break;
+        }
+    }
+}
+
+void UStatusEffectComponent::TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction)
+{
+    Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
+
+    AccumulatedTime += DeltaTime;
+    if (AccumulatedTime < 1.0f)
+    {
+        return;
+    }
+    AccumulatedTime = 0.f;
+
+    for (int32 i = ActiveEffects.Num() - 1; i >= 0; --i)
+    {
+        FActiveStatusEffect& Effect = ActiveEffects[i];
+        if (Effect.Duration > 0)
+        {
+            --Effect.Duration;
+            if (Effect.Duration <= 0)
+            {
+                ActiveEffects.RemoveAt(i);
+            }
+        }
+    }
+}

--- a/Source/ExodusProtocol/Public/AttackPatternComponent.h
+++ b/Source/ExodusProtocol/Public/AttackPatternComponent.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "CardPatternTypes.h"
+#include "Engine/DataTable.h"
+#include "AttackPatternComponent.generated.h"
+
+/** Chooses cards for enemy AI based on a weighted pattern table. */
+UCLASS(ClassGroup=(Custom), meta=(BlueprintSpawnableComponent))
+class EXODUSPROTOCOL_API UAttackPatternComponent : public UActorComponent
+{
+    GENERATED_BODY()
+public:
+    UAttackPatternComponent();
+
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Pattern")
+    UDataTable* PatternTable = nullptr;
+
+    /** Returns the ID of the next card to play. */
+    UFUNCTION(BlueprintCallable, Category="Pattern")
+    FName PickNextCard();
+
+protected:
+    virtual void BeginPlay() override;
+
+private:
+    FName LastCard;
+    int32 RepeatCount = 0;
+};

--- a/Source/ExodusProtocol/Public/CardComponent.h
+++ b/Source/ExodusProtocol/Public/CardComponent.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "CardTypes.h"
+#include "CardComponent.generated.h"
+
+class UStatusEffectComponent;
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FCardLifecycleEvent);
+
+/** Component representing a single card instance. */
+UCLASS(ClassGroup=(Custom), meta=(BlueprintSpawnableComponent))
+class EXODUSPROTOCOL_API UCardComponent : public UActorComponent
+{
+    GENERATED_BODY()
+public:
+    UCardComponent();
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Card")
+    FCardData CardData;
+
+    UPROPERTY(BlueprintAssignable, Category="Card")
+    FCardLifecycleEvent OnDraw;
+
+    UPROPERTY(BlueprintAssignable, Category="Card")
+    FCardLifecycleEvent OnPlay;
+
+    UPROPERTY(BlueprintAssignable, Category="Card")
+    FCardLifecycleEvent OnResolve;
+
+    UPROPERTY(BlueprintAssignable, Category="Card")
+    FCardLifecycleEvent OnDiscard;
+
+    UFUNCTION(BlueprintCallable, Category="Card")
+    void TriggerDraw();
+
+    UFUNCTION(BlueprintCallable, Category="Card")
+    void TriggerPlay();
+
+    UFUNCTION(BlueprintCallable, Category="Card")
+    void TriggerResolve();
+
+    UFUNCTION(BlueprintCallable, Category="Card")
+    void TriggerDiscard();
+
+protected:
+    virtual void BeginPlay() override;
+};

--- a/Source/ExodusProtocol/Public/CombatStatsComponent.h
+++ b/Source/ExodusProtocol/Public/CombatStatsComponent.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "CombatStatsComponent.generated.h"
+
+class UEventRouter;
+
+/** Tracks health, block and energy for an actor. */
+UCLASS(ClassGroup=(Custom), meta=(BlueprintSpawnableComponent))
+class EXODUSPROTOCOL_API UCombatStatsComponent : public UActorComponent
+{
+    GENERATED_BODY()
+public:
+    UCombatStatsComponent();
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Stats")
+    int32 Health = 10;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Stats")
+    int32 Block = 0;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Stats")
+    int32 Energy = 3;
+
+    UFUNCTION(BlueprintCallable, Category="Stats")
+    void ApplyDamage(int32 Amount);
+
+    UFUNCTION(BlueprintCallable, Category="Stats")
+    void AddBlock(int32 Amount);
+
+    UFUNCTION(BlueprintCallable, Category="Stats")
+    void AddEnergy(int32 Amount);
+
+private:
+    bool bIsDead = false;
+};

--- a/Source/ExodusProtocol/Public/EventRouter.h
+++ b/Source/ExodusProtocol/Public/EventRouter.h
@@ -12,6 +12,8 @@ DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FCardPlayedEvent,
     const FCardData&, CardData);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FDamageTakenEvent,
     AActor*, Target, int32, Amount);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FActorDiedEvent,
+    AActor*, DeadActor);
 
 UCLASS(BlueprintType)
 class EXODUSPROTOCOL_API UEventRouter : public UObject
@@ -23,4 +25,5 @@ public:
 
     UPROPERTY(BlueprintAssignable) FCardPlayedEvent  OnCardPlayed;
     UPROPERTY(BlueprintAssignable) FDamageTakenEvent OnDamageTaken;
+    UPROPERTY(BlueprintAssignable) FActorDiedEvent   OnActorDied;
 };

--- a/Source/ExodusProtocol/Public/StatusEffectComponent.h
+++ b/Source/ExodusProtocol/Public/StatusEffectComponent.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "StatusTypes.h"
+#include "Engine/DataTable.h"
+#include "StatusEffectComponent.generated.h"
+
+USTRUCT(BlueprintType)
+struct FActiveStatusEffect
+{
+    GENERATED_BODY()
+
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Status")
+    FName StatusID = NAME_None;
+
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Status")
+    int32 Stacks = 0;
+
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Status")
+    int32 Duration = 0;
+};
+
+/** Component that tracks active status effects on an Actor. */
+UCLASS(ClassGroup=(Custom), meta=(BlueprintSpawnableComponent))
+class EXODUSPROTOCOL_API UStatusEffectComponent : public UActorComponent
+{
+    GENERATED_BODY()
+public:
+    UStatusEffectComponent();
+
+    /** Apply the given status effect using optional stacks/duration overrides. */
+    UFUNCTION(BlueprintCallable, Category="Status")
+    void ApplyStatus(const FStatusEffectData& Data, int32 Stacks = 1, int32 Duration = 1);
+
+    /** Convenience look-up using the StatusDataTable and a GameplayTag. */
+    UFUNCTION(BlueprintCallable, Category="Status")
+    void ApplyStatusByTag(FGameplayTag StatusTag, int32 Stacks = 0, int32 Duration = 0);
+
+    virtual void TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
+
+    UPROPERTY(BlueprintReadOnly, Category="Status")
+    TArray<FActiveStatusEffect> ActiveEffects;
+
+protected:
+    virtual void BeginPlay() override;
+
+    /** Table used to resolve status tags into data rows. */
+    UPROPERTY(EditDefaultsOnly, Category="Status")
+    UDataTable* StatusDataTable = nullptr;
+
+private:
+    float AccumulatedTime = 0.f;
+};


### PR DESCRIPTION
## Summary
- implement `UCardComponent`, `UStatusEffectComponent`, `UAttackPatternComponent` and `UCombatStatsComponent`
- broadcast death events in `UEventRouter`
- connect `BPHelpers::ApplyStatusEffect` to `UStatusEffectComponent`
- document how to use the new components

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c307d24508326ac35e341c28eb34a