### PR TITLE
Add card lifecycle C++ classes

### DIFF
--- a/Source/ExodusProtocol/Private/CardActor.cpp
+++ b/Source/ExodusProtocol/Private/CardActor.cpp
@@ -1,0 +1,47 @@
+#include "CardActor.h"
+
+ACardActor::ACardActor()
+{
+    PrimaryActorTick.bCanEverTick = false;
+
+    CardComponent = CreateDefaultSubobject<UCardComponent>(TEXT("CardComponent"));
+    RootComponent = CardComponent;
+}
+
+void ACardActor::MoveToZone(ECardZone NewZone)
+{
+    if (CardZone == NewZone)
+    {
+        return;
+    }
+
+    const ECardZone OldZone = CardZone;
+    CardZone = NewZone;
+
+    if (!CardComponent)
+    {
+        return;
+    }
+
+    if (OldZone == ECardZone::DrawPile && NewZone == ECardZone::Hand)
+    {
+        CardComponent->TriggerDraw();
+    }
+    else if (OldZone == ECardZone::Hand && NewZone == ECardZone::Queue)
+    {
+        CardComponent->TriggerPlay();
+        if (UEventRouter* Router = UEventRouter::Get(this))
+        {
+            Router->OnCardPlayed.Broadcast(CardComponent->CardData);
+        }
+    }
+
+    if (NewZone == ECardZone::Grave)
+    {
+        if (OldZone == ECardZone::Queue)
+        {
+            CardComponent->TriggerResolve();
+        }
+        CardComponent->TriggerDiscard();
+    }
+}

--- a/Source/ExodusProtocol/Private/CardWidget.cpp
+++ b/Source/ExodusProtocol/Private/CardWidget.cpp
@@ -1,0 +1,36 @@
+#include "CardWidget.h"
+#include "CardComponent.h"
+
+void UCardWidget::InitWithComponent(UCardComponent* Component)
+{
+    if (!Component)
+    {
+        return;
+    }
+
+    CardComponent = Component;
+    Component->OnDraw.AddDynamic(this, &UCardWidget::HandleDraw);
+    Component->OnPlay.AddDynamic(this, &UCardWidget::HandlePlay);
+    Component->OnResolve.AddDynamic(this, &UCardWidget::HandleResolve);
+    Component->OnDiscard.AddDynamic(this, &UCardWidget::HandleDiscard);
+}
+
+void UCardWidget::HandleDraw()
+{
+    OnCardDrawn();
+}
+
+void UCardWidget::HandlePlay()
+{
+    OnCardPlayed();
+}
+
+void UCardWidget::HandleResolve()
+{
+    OnCardResolved();
+}
+
+void UCardWidget::HandleDiscard()
+{
+    OnCardDiscarded();
+}

--- a/Source/ExodusProtocol/Public/CardActor.h
+++ b/Source/ExodusProtocol/Public/CardActor.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "CardComponent.h"
+#include "EventRouter.h"
+#include "CardActor.generated.h"
+
+/** Zones a card can occupy during play. */
+UENUM(BlueprintType)
+enum class ECardZone : uint8
+{
+    DrawPile UMETA(DisplayName="DrawPile"),
+    Hand     UMETA(DisplayName="Hand"),
+    Queue    UMETA(DisplayName="Queue"),
+    Grave    UMETA(DisplayName="Grave")
+};
+
+/** Actor representing a card instance that moves between draw pile, hand, queue and grave. */
+UCLASS()
+class EXODUSPROTOCOL_API ACardActor : public AActor
+{
+    GENERATED_BODY()
+public:
+    ACardActor();
+
+    /** Current lifecycle zone. */
+    UPROPERTY(BlueprintReadOnly, Category="Card")
+    ECardZone CardZone = ECardZone::DrawPile;
+
+    /** Component holding card data and events. */
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="Card")
+    TObjectPtr<UCardComponent> CardComponent;
+
+    /** Move to a new zone and fire the relevant lifecycle events. */
+    UFUNCTION(BlueprintCallable, Category="Card")
+    void MoveToZone(ECardZone NewZone);
+};

--- a/Source/ExodusProtocol/Public/CardWidget.h
+++ b/Source/ExodusProtocol/Public/CardWidget.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "CardWidget.generated.h"
+
+class UCardComponent;
+
+/** UI widget that displays a card and reacts to lifecycle events. */
+UCLASS()
+class EXODUSPROTOCOL_API UCardWidget : public UUserWidget
+{
+    GENERATED_BODY()
+public:
+    /** Bind this widget to a card component so it reacts to events. */
+    UFUNCTION(BlueprintCallable, Category="Card")
+    void InitWithComponent(UCardComponent* Component);
+
+protected:
+    UPROPERTY(BlueprintReadOnly, Category="Card")
+    TObjectPtr<UCardComponent> CardComponent = nullptr;
+
+    UFUNCTION(BlueprintImplementableEvent, Category="Card")
+    void OnCardDrawn();
+
+    UFUNCTION(BlueprintImplementableEvent, Category="Card")
+    void OnCardPlayed();
+
+    UFUNCTION(BlueprintImplementableEvent, Category="Card")
+    void OnCardResolved();
+
+    UFUNCTION(BlueprintImplementableEvent, Category="Card")
+    void OnCardDiscarded();
+
+private:
+    UFUNCTION()
+    void HandleDraw();
+
+    UFUNCTION()
+    void HandlePlay();
+
+    UFUNCTION()
+    void HandleResolve();
+
+    UFUNCTION()
+    void HandleDiscard();
+};


### PR DESCRIPTION
## Summary
- add `ECardZone` enum and `ACardActor` to manage card lifecycle
- add `UCardWidget` that hooks into `UCardComponent` events

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c3508da988326b670671c466eb309