### PR TITLE
Update README to mark event dispatcher complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🃏 Unreal Engine 5.6 Card-Battler – Blueprint Framework
 
-### 📈 Progress  **5 / 16 steps complete (≈ 31 %)**
+### 📈 Progress  **6 / 16 steps complete (≈ 38 %)**
 
 | ✔ | # | 🎯 Goal | 🔑 Blueprint / Asset Types | 🧩 What You Build |
 |:-:|---|---------|---------------------------|------------------|
@@ -9,7 +9,7 @@
 | ✅ | 2 | **Component actors** | `UCardComponent`, `UStatusEffectComponent`, `UAttackPatternComponent`, `UCombatStatsComponent` | Build pawns/enemies/cards by stacking components → reusable & testable. <br/>*Docs → Actor Components* |
 | ✅ | 3 | **Card lifecycle** | `BP_CardActor` (world) + `BP_CardWidget` (UI) | States: *DrawPile → Hand → Queue → Grave*. Fire events: `OnDraw`, `OnPlay`, `OnResolve`, `OnDiscard`. <br/>*Docs → Gameplay Framework* |
 | ✅ | 4 | **Turn manager** | `BP_CombatManager` | Controls loop: *StartTurn → Player → Enemy → EndTurn*. Tracks rounds, energy, win/loss. <br/>*Docs → Timers & Tick* |
-| ⬜ | 5 | **Event bus** | `BP_EventRouter` (on GameInstance) **or** Blueprint Interface | Publish/Subscribe: e.g. `"CardPlayed"`, `"DamageTaken"`; loose coupling. <br/>*Docs → Blueprint Dispatchers* |
+| ✅ | 5 | **Event bus** | `UEventRouter` (GameMode subobject) | Publish/Subscribe: e.g. `"CardPlayed"`, `"DamageTaken"`; loose coupling. <br/>*Docs → Blueprint Dispatchers* |
 | ⬜ | 6 | **Rich UI** | `BP_HUD_Widget` root + Hand, DrawPile, Discard, Tooltip, EnemyIntent, StatusBars | Widgets listen to the event bus; use Widget Animations for flashes. <br/>*Docs → UMG Basics, Binding* |
 | ⬜ | 7 | **Enemy AI** | `UAttackPatternComponent` + DataTable | Rows: Ability, Weight, RepeatLimit, Tag. Chooses next ability each Enemy phase; broadcasts `"SelectedIntent"`. <br/>*Docs → Data-Driven AI* |
 | ⬜ | 8 | **Rewards** | `BP_RewardManager` (GameMode sub-object) | Pools cards/artifacts by rarity; `GiveRewards()` spawns pick screen. <br/>*Docs → Random Streams, Gameplay Tags* |


### PR DESCRIPTION
## Summary
- update progress indicator to 6/16 steps
- mark the Event Bus step complete and describe the `UEventRouter`

## Testing
- `grep -n "Progress" -n README.md`


------
https://chatgpt.com/codex/tasks/task_e_686c406726f88326bbcf330380012fc8