### PR TITLE
Add intent selected event

### DIFF
--- a/Source/ExodusProtocol/Private/AttackPatternComponent.cpp
+++ b/Source/ExodusProtocol/Private/AttackPatternComponent.cpp
@@ -1,5 +1,6 @@
 #include "AttackPatternComponent.h"
 #include "Engine/DataTable.h"
+#include "EventRouter.h"
 
 UAttackPatternComponent::UAttackPatternComponent()
 {
@@ -56,6 +57,10 @@ FName UAttackPatternComponent::PickNextCard()
             {
                 LastCard = Row->CardID;
                 RepeatCount = 1;
+            }
+            if (UEventRouter* Router = UEventRouter::Get(this))
+            {
+                Router->OnIntentSelected.Broadcast(Row->CardID, Row->PatternTag);
             }
             return Row->CardID;
         }

--- a/Source/ExodusProtocol/Private/EventRouter.cpp
+++ b/Source/ExodusProtocol/Private/EventRouter.cpp
@@ -1,6 +1,7 @@
 //=== EventRouter.cpp ======================================================
 #include "EventRouter.h"
 #include "Kismet/GameplayStatics.h"
+#include "GameplayTagContainer.h" // For FGameplayTag in delegates
 #include "CoreGameMode.h"
 
 UEventRouter* UEventRouter::Get(const UObject* WorldContext)

--- a/Source/ExodusProtocol/Public/EventRouter.h
+++ b/Source/ExodusProtocol/Public/EventRouter.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "CoreMinimal.h"
 #include "UObject/Object.h"
+#include "GameplayTagContainer.h"
 
 /*  Must sit **before** the generated include so
     the delegate macros can see FCardData           */
@@ -14,6 +15,8 @@ DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FDamageTakenEvent,
     AActor*, Target, int32, Amount);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FActorDiedEvent,
     AActor*, DeadActor);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FIntentSelectedEvent,
+    FName, CardID, FGameplayTag, PatternTag);
 
 UCLASS(BlueprintType)
 class EXODUSPROTOCOL_API UEventRouter : public UObject
@@ -26,4 +29,5 @@ public:
     UPROPERTY(BlueprintAssignable) FCardPlayedEvent  OnCardPlayed;
     UPROPERTY(BlueprintAssignable) FDamageTakenEvent OnDamageTaken;
     UPROPERTY(BlueprintAssignable) FActorDiedEvent   OnActorDied;
+    UPROPERTY(BlueprintAssignable) FIntentSelectedEvent OnIntentSelected;
 };


### PR DESCRIPTION
## Summary
- expose new `FIntentSelectedEvent` delegate from `UEventRouter`
- include gameplay tag headers for compilation
- broadcast intent selection when `UAttackPatternComponent` chooses a card

## Testing
- `echo "No tests"`

------
https://chatgpt.com/codex/tasks/task_e_686c45a5dff48326bbfc23b6f256eb1d