### PR TITLE
Add shop and story event types

### DIFF
--- a/Source/ExodusProtocol/Private/ShopTypes.cpp
+++ b/Source/ExodusProtocol/Private/ShopTypes.cpp
@@ -1,0 +1,1 @@
+#include "ShopTypes.h"

--- a/Source/ExodusProtocol/Private/StoryEventTypes.cpp
+++ b/Source/ExodusProtocol/Private/StoryEventTypes.cpp
@@ -1,0 +1,1 @@
+#include "StoryEventTypes.h"

--- a/Source/ExodusProtocol/Public/ShopTypes.h
+++ b/Source/ExodusProtocol/Public/ShopTypes.h
@@ -1,0 +1,49 @@
+//=== ShopTypes.h ===========================================================
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/DataTable.h"
+
+#include "ShopTypes.generated.h"
+
+/** Type of item a shop entry sells. */
+UENUM(BlueprintType)
+enum class EShopItemType : uint8
+{
+    Card        UMETA(DisplayName = "Card"),
+    Artifact    UMETA(DisplayName = "Artifact")
+};
+
+/** Row for an item sold in a shop. */
+USTRUCT(BlueprintType)
+struct FShopItemData : public FTableRowBase
+{
+    GENERATED_BODY();
+
+    /** Whether this is a card or artifact. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Shop")
+    EShopItemType ItemType = EShopItemType::Card;
+
+    /** ID referencing a card or artifact row. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Shop")
+    FName ItemID = NAME_None;
+
+    /** Price in whatever currency your game uses. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Shop")
+    int32 Price = 0;
+};
+
+/** Collection of items a shop offers. */
+USTRUCT(BlueprintType)
+struct FShopData : public FTableRowBase
+{
+    GENERATED_BODY();
+
+    /** Row identifier for lookups. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Shop")
+    FName ShopID = NAME_None;
+
+    /** Items that this shop can sell. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Shop")
+    TArray<FShopItemData> Items;
+};

--- a/Source/ExodusProtocol/Public/StoryEventTypes.h
+++ b/Source/ExodusProtocol/Public/StoryEventTypes.h
@@ -1,0 +1,41 @@
+//=== StoryEventTypes.h =====================================================
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/DataTable.h"
+
+#include "StoryEventTypes.generated.h"
+
+/** Player choice option within a story event. */
+USTRUCT(BlueprintType)
+struct FStoryChoice
+{
+    GENERATED_BODY();
+
+    /** Text displayed for this choice. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Story")
+    FText ChoiceText;
+
+    /** ID of the payload triggered when chosen. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Story")
+    FName PayloadID = NAME_None;
+};
+
+/** Row describing a full story event. */
+USTRUCT(BlueprintType)
+struct FStoryEventData : public FTableRowBase
+{
+    GENERATED_BODY();
+
+    /** Unique identifier for this event. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Story")
+    FName EventID = NAME_None;
+
+    /** Intro snippet shown before choices. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Story")
+    FText SnippetText;
+
+    /** Choices presented to the player. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Story")
+    TArray<FStoryChoice> Choices;
+};


### PR DESCRIPTION
## Summary
- define `ShopTypes` with item and shop data structures
- define `StoryEventTypes` for dialogue snippet choices
- add simple cpp files for UE build

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c53e165d083268a83927469ed8b64