### PR TITLE
Add node activation handling

### DIFF
--- a/Source/ExodusProtocol/Private/NodeMapWidget.cpp
+++ b/Source/ExodusProtocol/Private/NodeMapWidget.cpp
@@ -1,7 +1,59 @@
 #include "NodeMapWidget.h"
 #include "NodeActor.h"
+#include "ShopWidget.h"
+#include "StoryEventWidget.h"
+#include "ShopTypes.h"
+#include "StoryEventTypes.h"
+#include "Engine/DataTable.h"
 
 void UNodeMapWidget::InitWithNodes(const TArray<ANodeActor*>& Nodes)
 {
     MapNodes = Nodes;
+}
+
+void UNodeMapWidget::HandleNodeActivated(ANodeActor* Node)
+{
+    if (!Node) { return; }
+
+    const FEncounterNodeData& Data = Node->NodeData;
+
+    switch (Data.NodeType)
+    {
+        case ENodeType::Shop:
+        {
+            if (ShopDataTable && !Data.PayloadID.IsNone())
+            {
+                const FShopData* Row = ShopDataTable->FindRow<FShopData>(Data.PayloadID, TEXT("HandleNodeActivated"));
+                if (Row)
+                {
+                    TSubclassOf<UShopWidget> WidgetClass = ShopWidgetClass ? ShopWidgetClass : UShopWidget::StaticClass();
+                    if (UShopWidget* Widget = CreateWidget<UShopWidget>(GetWorld(), WidgetClass))
+                    {
+                        Widget->InitWithData(*Row);
+                        Widget->AddToViewport();
+                    }
+                }
+            }
+            break;
+        }
+        case ENodeType::Story:
+        {
+            if (StoryEventTable && !Data.PayloadID.IsNone())
+            {
+                const FStoryEventData* Row = StoryEventTable->FindRow<FStoryEventData>(Data.PayloadID, TEXT("HandleNodeActivated"));
+                if (Row)
+                {
+                    TSubclassOf<UStoryEventWidget> WidgetClass = StoryEventWidgetClass ? StoryEventWidgetClass : UStoryEventWidget::StaticClass();
+                    if (UStoryEventWidget* Widget = CreateWidget<UStoryEventWidget>(GetWorld(), WidgetClass))
+                    {
+                        Widget->InitWithData(*Row);
+                        Widget->AddToViewport();
+                    }
+                }
+            }
+            break;
+        }
+        default:
+            break;
+    }
 }

--- a/Source/ExodusProtocol/Public/NodeMapWidget.h
+++ b/Source/ExodusProtocol/Public/NodeMapWidget.h
@@ -2,9 +2,12 @@
 
 #include "CoreMinimal.h"
 #include "Blueprint/UserWidget.h"
+#include "Engine/DataTable.h"
 #include "NodeMapWidget.generated.h"
 
 class ANodeActor;
+class UShopWidget;
+class UStoryEventWidget;
 
 /** Widget that displays and interacts with map nodes. */
 UCLASS()
@@ -16,6 +19,10 @@ public:
     UFUNCTION(BlueprintCallable, Category="Map")
     void InitWithNodes(const TArray<ANodeActor*>& Nodes);
 
+    /** Called when a node has been activated by the player. */
+    UFUNCTION(BlueprintCallable, Category="Map")
+    void HandleNodeActivated(ANodeActor* Node);
+
     /** Called when the player selects a node. */
     UFUNCTION(BlueprintImplementableEvent, Category="Map")
     void OnNodeSelected(ANodeActor* SelectedNode);
@@ -23,4 +30,20 @@ public:
 protected:
     UPROPERTY(BlueprintReadOnly, Category="Map")
     TArray<ANodeActor*> MapNodes;
+
+    /** Data table containing shop definitions. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Map")
+    UDataTable* ShopDataTable = nullptr;
+
+    /** Data table containing story events. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Map")
+    UDataTable* StoryEventTable = nullptr;
+
+    /** Widget class used to present shop UIs. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Map")
+    TSubclassOf<UShopWidget> ShopWidgetClass;
+
+    /** Widget class used to present story events. */
+    UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Map")
+    TSubclassOf<UStoryEventWidget> StoryEventWidgetClass;
 };


### PR DESCRIPTION
## Summary
- extend `UNodeMapWidget` with `HandleNodeActivated`
- support creating shop and story widgets when a node is activated
- expose widget classes and datatables for shops and stories

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c572e2f9883268834a79be73df3a4