### PR TITLE
Add basic save/load subsystem

### DIFF
--- a/Source/ExodusProtocol/Private/NodeMapWidget.cpp
+++ b/Source/ExodusProtocol/Private/NodeMapWidget.cpp
@@ -5,6 +5,7 @@
 #include "ShopTypes.h"
 #include "StoryEventTypes.h"
 #include "Engine/DataTable.h"
+#include "SaveSubsystem.h"
 
 void UNodeMapWidget::InitWithNodes(const TArray<ANodeActor*>& Nodes)
 {
@@ -55,5 +56,18 @@ void UNodeMapWidget::HandleNodeActivated(ANodeActor* Node)
         }
         default:
             break;
+    }
+
+    if (UGameInstance* GI = GetGameInstance())
+    {
+        if (USaveSubsystem* Subsystem = GI->GetSubsystem<USaveSubsystem>())
+        {
+            USaveGame_RunState* State = Subsystem->LoadRunState();
+            if (!State)
+            {
+                State = NewObject<USaveGame_RunState>();
+            }
+            Subsystem->SaveRunState(State);
+        }
     }
 }

--- a/Source/ExodusProtocol/Private/SaveGameRunState.cpp
+++ b/Source/ExodusProtocol/Private/SaveGameRunState.cpp
@@ -1,0 +1,3 @@
+#include "SaveGameRunState.h"
+
+// Empty source file required for UHT.

--- a/Source/ExodusProtocol/Private/SaveSubsystem.cpp
+++ b/Source/ExodusProtocol/Private/SaveSubsystem.cpp
@@ -1,0 +1,25 @@
+#include "SaveSubsystem.h"
+#include "Kismet/GameplayStatics.h"
+
+const FString USaveSubsystem::SlotName = TEXT("RunState");
+
+bool USaveSubsystem::SaveRunState(USaveGame_RunState* State)
+{
+    if (!State) { return false; }
+    return UGameplayStatics::SaveGameToSlot(State, SlotName, 0);
+}
+
+USaveGame_RunState* USaveSubsystem::LoadRunState()
+{
+    if (USaveGame* Loaded = UGameplayStatics::LoadGameFromSlot(SlotName, 0))
+    {
+        return Cast<USaveGame_RunState>(Loaded);
+    }
+    return nullptr;
+}
+
+void USaveSubsystem::DeleteSave()
+{
+    UGameplayStatics::DeleteGameInSlot(SlotName, 0);
+}
+

--- a/Source/ExodusProtocol/Private/Tests/SaveSubsystemTests.cpp
+++ b/Source/ExodusProtocol/Private/Tests/SaveSubsystemTests.cpp
@@ -1,0 +1,33 @@
+#include "Misc/AutomationTest.h"
+#include "SaveSubsystem.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSaveSubsystemRoundTrip, "ExodusProtocol.SaveSubsystem.SaveLoad", EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+bool FSaveSubsystemRoundTrip::RunTest(const FString& Parameters)
+{
+    USaveSubsystem* Subsys = NewObject<USaveSubsystem>();
+    USaveGame_RunState* Saved = NewObject<USaveGame_RunState>();
+    Saved->DeckCardIDs = { FName("C1"), FName("C2") };
+    Saved->VisitedNodeIDs = { FName("N1"), FName("N2") };
+
+    TestTrue(TEXT("Save success"), Subsys->SaveRunState(Saved));
+
+    USaveGame_RunState* Loaded = Subsys->LoadRunState();
+    TestTrue(TEXT("Loaded not null"), Loaded != nullptr);
+    if (Loaded)
+    {
+        TestEqual(TEXT("Deck count"), Loaded->DeckCardIDs.Num(), Saved->DeckCardIDs.Num());
+        for (int32 i = 0; i < Saved->DeckCardIDs.Num(); ++i)
+        {
+            TestEqual(FString::Printf(TEXT("DeckID %d"), i), Loaded->DeckCardIDs[i], Saved->DeckCardIDs[i]);
+        }
+        TestEqual(TEXT("Visited count"), Loaded->VisitedNodeIDs.Num(), Saved->VisitedNodeIDs.Num());
+        for (int32 i = 0; i < Saved->VisitedNodeIDs.Num(); ++i)
+        {
+            TestEqual(FString::Printf(TEXT("NodeID %d"), i), Loaded->VisitedNodeIDs[i], Saved->VisitedNodeIDs[i]);
+        }
+    }
+
+    Subsys->DeleteSave();
+    return true;
+}
+

--- a/Source/ExodusProtocol/Public/SaveGameRunState.h
+++ b/Source/ExodusProtocol/Public/SaveGameRunState.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/SaveGame.h"
+#include "StatusEffectComponent.h"
+#include "SaveGameRunState.generated.h"
+
+/** Save data for a single run. */
+UCLASS()
+class EXODUSPROTOCOL_API USaveGame_RunState : public USaveGame
+{
+    GENERATED_BODY()
+public:
+    /** Player health points. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="RunState")
+    int32 PlayerHP = 0;
+
+    /** Current gold amount. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="RunState")
+    int32 Gold = 0;
+
+    /** Current cards in the player's deck. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="RunState")
+    TArray<FName> DeckCardIDs;
+
+    /** Owned artifact identifiers. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="RunState")
+    TArray<FName> ArtifactIDs;
+
+    /** Nodes visited on the world map. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="RunState")
+    TArray<FName> VisitedNodeIDs;
+
+    /** Random number generator seed. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="RunState")
+    int32 RNGSeed = 0;
+
+    /** ID of the currently selected deck (step 11A). */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="RunState")
+    FName CurrentDeckID = NAME_None;
+
+    /** Owned attack pattern identifiers (step 11A). */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="RunState")
+    TArray<FName> OwnedPatternIDs;
+
+    /** Status effects per minion (step 11A). */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="RunState")
+    TMap<FName, TArray<FActiveStatusEffect>> MinionStatuses;
+};
+

--- a/Source/ExodusProtocol/Public/SaveSubsystem.h
+++ b/Source/ExodusProtocol/Public/SaveSubsystem.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Subsystems/GameInstanceSubsystem.h"
+#include "SaveGameRunState.h"
+#include "SaveSubsystem.generated.h"
+
+/** Simple subsystem wrapping SaveGame operations. */
+UCLASS()
+class EXODUSPROTOCOL_API USaveSubsystem : public UGameInstanceSubsystem
+{
+    GENERATED_BODY()
+public:
+    /** Save the given run state to disk. */
+    UFUNCTION(BlueprintCallable, Category="Save")
+    bool SaveRunState(USaveGame_RunState* State);
+
+    /** Load the run state from disk. */
+    UFUNCTION(BlueprintCallable, Category="Save")
+    USaveGame_RunState* LoadRunState();
+
+    /** Delete the current save slot. */
+    UFUNCTION(BlueprintCallable, Category="Save")
+    void DeleteSave();
+
+private:
+    static const FString SlotName;
+};
+


### PR DESCRIPTION
## Summary
- add `USaveGame_RunState` with fields for player data and step-11A values
- implement `USaveSubsystem` for saving/loading/deleting run state
- autosave in `NodeMapWidget::HandleNodeActivated`
- add automation test covering save/load roundtrip

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686cf81556848326824d77dabab6203c