### PR TITLE
Add setters for run-state fields

### DIFF
--- a/Source/ExodusProtocol/Private/SaveSubsystem.cpp
+++ b/Source/ExodusProtocol/Private/SaveSubsystem.cpp
@@ -23,3 +23,102 @@ void USaveSubsystem::DeleteSave()
     UGameplayStatics::DeleteGameInSlot(SlotName, 0);
 }
 
+void USaveSubsystem::SetPlayerHP(int32 NewHP)
+{
+    USaveGame_RunState* State = LoadRunState();
+    if (!State)
+    {
+        State = NewObject<USaveGame_RunState>();
+    }
+    State->PlayerHP = NewHP;
+    SaveRunState(State);
+}
+
+void USaveSubsystem::SetGold(int32 NewGold)
+{
+    USaveGame_RunState* State = LoadRunState();
+    if (!State)
+    {
+        State = NewObject<USaveGame_RunState>();
+    }
+    State->Gold = NewGold;
+    SaveRunState(State);
+}
+
+void USaveSubsystem::SetDeckCardIDs(const TArray<FName>& NewIDs)
+{
+    USaveGame_RunState* State = LoadRunState();
+    if (!State)
+    {
+        State = NewObject<USaveGame_RunState>();
+    }
+    State->DeckCardIDs = NewIDs;
+    SaveRunState(State);
+}
+
+void USaveSubsystem::SetArtifactIDs(const TArray<FName>& NewIDs)
+{
+    USaveGame_RunState* State = LoadRunState();
+    if (!State)
+    {
+        State = NewObject<USaveGame_RunState>();
+    }
+    State->ArtifactIDs = NewIDs;
+    SaveRunState(State);
+}
+
+void USaveSubsystem::SetCurrentDeckID(FName DeckID)
+{
+    USaveGame_RunState* State = LoadRunState();
+    if (!State)
+    {
+        State = NewObject<USaveGame_RunState>();
+    }
+    State->CurrentDeckID = DeckID;
+    SaveRunState(State);
+}
+
+void USaveSubsystem::SetVisitedNodeIDs(const TArray<FName>& NewIDs)
+{
+    USaveGame_RunState* State = LoadRunState();
+    if (!State)
+    {
+        State = NewObject<USaveGame_RunState>();
+    }
+    State->VisitedNodeIDs = NewIDs;
+    SaveRunState(State);
+}
+
+void USaveSubsystem::SetRNGSeed(int32 Seed)
+{
+    USaveGame_RunState* State = LoadRunState();
+    if (!State)
+    {
+        State = NewObject<USaveGame_RunState>();
+    }
+    State->RNGSeed = Seed;
+    SaveRunState(State);
+}
+
+void USaveSubsystem::SetOwnedPatternIDs(const TArray<FName>& NewIDs)
+{
+    USaveGame_RunState* State = LoadRunState();
+    if (!State)
+    {
+        State = NewObject<USaveGame_RunState>();
+    }
+    State->OwnedPatternIDs = NewIDs;
+    SaveRunState(State);
+}
+
+void USaveSubsystem::SetMinionStatuses(const TMap<FName, TArray<FActiveStatusEffect>>& Statuses)
+{
+    USaveGame_RunState* State = LoadRunState();
+    if (!State)
+    {
+        State = NewObject<USaveGame_RunState>();
+    }
+    State->MinionStatuses = Statuses;
+    SaveRunState(State);
+}
+

--- a/Source/ExodusProtocol/Private/Tests/SaveSubsystemTests.cpp
+++ b/Source/ExodusProtocol/Private/Tests/SaveSubsystemTests.cpp
@@ -8,8 +8,12 @@ bool FSaveSubsystemRoundTrip::RunTest(const FString& Parameters)
     USaveGame_RunState* Saved = NewObject<USaveGame_RunState>();
     Saved->DeckCardIDs = { FName("C1"), FName("C2") };
     Saved->VisitedNodeIDs = { FName("N1"), FName("N2") };
+    Saved->Gold = 5;
 
     TestTrue(TEXT("Save success"), Subsys->SaveRunState(Saved));
+
+    // Update gold through the subsystem setter
+    Subsys->SetGold(42);
 
     USaveGame_RunState* Loaded = Subsys->LoadRunState();
     TestTrue(TEXT("Loaded not null"), Loaded != nullptr);
@@ -25,6 +29,7 @@ bool FSaveSubsystemRoundTrip::RunTest(const FString& Parameters)
         {
             TestEqual(FString::Printf(TEXT("NodeID %d"), i), Loaded->VisitedNodeIDs[i], Saved->VisitedNodeIDs[i]);
         }
+        TestEqual(TEXT("Gold updated"), Loaded->Gold, 42);
     }
 
     Subsys->DeleteSave();

--- a/Source/ExodusProtocol/Public/SaveSubsystem.h
+++ b/Source/ExodusProtocol/Public/SaveSubsystem.h
@@ -5,7 +5,12 @@
 #include "SaveGameRunState.h"
 #include "SaveSubsystem.generated.h"
 
-/** Simple subsystem wrapping SaveGame operations. */
+/**
+ * Simple subsystem wrapping SaveGame operations.
+ * Other systems should call the Blueprint functions below whenever
+ * player data such as health, gold or deck contents changes so the
+ * run state stays persisted to disk.
+ */
 UCLASS()
 class EXODUSPROTOCOL_API USaveSubsystem : public UGameInstanceSubsystem
 {
@@ -22,6 +27,42 @@ public:
     /** Delete the current save slot. */
     UFUNCTION(BlueprintCallable, Category="Save")
     void DeleteSave();
+
+    /** Update the player's current HP value on disk. */
+    UFUNCTION(BlueprintCallable, Category="Save")
+    void SetPlayerHP(int32 NewHP);
+
+    /** Update the player's current gold amount on disk. */
+    UFUNCTION(BlueprintCallable, Category="Save")
+    void SetGold(int32 NewGold);
+
+    /** Replace the player's deck card IDs on disk. */
+    UFUNCTION(BlueprintCallable, Category="Save")
+    void SetDeckCardIDs(const TArray<FName>& NewIDs);
+
+    /** Replace the player's owned artifact IDs on disk. */
+    UFUNCTION(BlueprintCallable, Category="Save")
+    void SetArtifactIDs(const TArray<FName>& NewIDs);
+
+    /** Set the ID of the currently selected deck on disk. */
+    UFUNCTION(BlueprintCallable, Category="Save")
+    void SetCurrentDeckID(FName DeckID);
+
+    /** Replace visited node IDs on disk. */
+    UFUNCTION(BlueprintCallable, Category="Save")
+    void SetVisitedNodeIDs(const TArray<FName>& NewIDs);
+
+    /** Update the RNG seed value on disk. */
+    UFUNCTION(BlueprintCallable, Category="Save")
+    void SetRNGSeed(int32 Seed);
+
+    /** Replace owned attack pattern IDs on disk. */
+    UFUNCTION(BlueprintCallable, Category="Save")
+    void SetOwnedPatternIDs(const TArray<FName>& NewIDs);
+
+    /** Replace all saved minion statuses on disk. */
+    UFUNCTION(BlueprintCallable, Category="Save")
+    void SetMinionStatuses(const TMap<FName, TArray<FActiveStatusEffect>>& Statuses);
 
 private:
     static const FString SlotName;


### PR DESCRIPTION
## Summary
- extend SaveSubsystem with functions for updating run state values
- document these functions in the header
- update unit test to use SetGold

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_686d14f728448326b104a738f970c36b