### PR TITLE
Switch MinionStatuses to dedicated struct

### DIFF
--- a/Source/ExodusProtocol/Private/SaveSubsystem.cpp
+++ b/Source/ExodusProtocol/Private/SaveSubsystem.cpp
@@ -111,7 +111,7 @@ void USaveSubsystem::SetOwnedPatternIDs(const TArray<FName>& NewIDs)
     SaveRunState(State);
 }
 
-void USaveSubsystem::SetMinionStatuses(const TMap<FName, TArray<FActiveStatusEffect>>& Statuses)
+void USaveSubsystem::SetMinionStatuses(const TMap<FName, FMinionStatusArray>& Statuses)
 {
     USaveGame_RunState* State = LoadRunState();
     if (!State)

--- a/Source/ExodusProtocol/Public/SaveGameRunState.h
+++ b/Source/ExodusProtocol/Public/SaveGameRunState.h
@@ -5,6 +5,15 @@
 #include "StatusEffectComponent.h"
 #include "SaveGameRunState.generated.h"
 
+USTRUCT(BlueprintType)
+struct FMinionStatusArray
+{
+    GENERATED_BODY()
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Status")
+    TArray<FActiveStatusEffect> Effects;
+};
+
 /** Save data for a single run. */
 UCLASS()
 class EXODUSPROTOCOL_API USaveGame_RunState : public USaveGame
@@ -45,6 +54,6 @@ public:
 
     /** Status effects per minion (step 11A). */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="RunState")
-    TMap<FName, TArray<FActiveStatusEffect>> MinionStatuses;
+    TMap<FName, FMinionStatusArray> MinionStatuses;
 };
 

--- a/Source/ExodusProtocol/Public/SaveSubsystem.h
+++ b/Source/ExodusProtocol/Public/SaveSubsystem.h
@@ -62,7 +62,7 @@ public:
 
     /** Replace all saved minion statuses on disk. */
     UFUNCTION(BlueprintCallable, Category="Save")
-    void SetMinionStatuses(const TMap<FName, TArray<FActiveStatusEffect>>& Statuses);
+    void SetMinionStatuses(const TMap<FName, FMinionStatusArray>& Statuses);
 
 private:
     static const FString SlotName;


### PR DESCRIPTION
## Summary
- add `FMinionStatusArray` struct to wrap an array of `FActiveStatusEffect`
- store minion statuses on save games using `TMap<FName, FMinionStatusArray>`
- update `USaveSubsystem::SetMinionStatuses` to accept the new map type

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d47888c4883269c54d4b9b9bb5e39