### PR TITLE
Refactor SaveSubsystem state loading

### DIFF
--- a/Source/ExodusProtocol/Private/SaveSubsystem.cpp
+++ b/Source/ExodusProtocol/Private/SaveSubsystem.cpp
@@ -3,6 +3,16 @@
 
 const FString USaveSubsystem::SlotName = TEXT("RunState");
 
+USaveGame_RunState* USaveSubsystem::GetOrCreateState()
+{
+    USaveGame_RunState* State = LoadRunState();
+    if (!State)
+    {
+        State = NewObject<USaveGame_RunState>();
+    }
+    return State;
+}
+
 bool USaveSubsystem::SaveRunState(USaveGame_RunState* State)
 {
     if (!State) { return false; }
@@ -25,99 +35,63 @@ void USaveSubsystem::DeleteSave()
 
 void USaveSubsystem::SetPlayerHP(int32 NewHP)
 {
-    USaveGame_RunState* State = LoadRunState();
-    if (!State)
-    {
-        State = NewObject<USaveGame_RunState>();
-    }
+    USaveGame_RunState* State = GetOrCreateState();
     State->PlayerHP = NewHP;
     SaveRunState(State);
 }
 
 void USaveSubsystem::SetGold(int32 NewGold)
 {
-    USaveGame_RunState* State = LoadRunState();
-    if (!State)
-    {
-        State = NewObject<USaveGame_RunState>();
-    }
+    USaveGame_RunState* State = GetOrCreateState();
     State->Gold = NewGold;
     SaveRunState(State);
 }
 
 void USaveSubsystem::SetDeckCardIDs(const TArray<FName>& NewIDs)
 {
-    USaveGame_RunState* State = LoadRunState();
-    if (!State)
-    {
-        State = NewObject<USaveGame_RunState>();
-    }
+    USaveGame_RunState* State = GetOrCreateState();
     State->DeckCardIDs = NewIDs;
     SaveRunState(State);
 }
 
 void USaveSubsystem::SetArtifactIDs(const TArray<FName>& NewIDs)
 {
-    USaveGame_RunState* State = LoadRunState();
-    if (!State)
-    {
-        State = NewObject<USaveGame_RunState>();
-    }
+    USaveGame_RunState* State = GetOrCreateState();
     State->ArtifactIDs = NewIDs;
     SaveRunState(State);
 }
 
 void USaveSubsystem::SetCurrentDeckID(FName DeckID)
 {
-    USaveGame_RunState* State = LoadRunState();
-    if (!State)
-    {
-        State = NewObject<USaveGame_RunState>();
-    }
+    USaveGame_RunState* State = GetOrCreateState();
     State->CurrentDeckID = DeckID;
     SaveRunState(State);
 }
 
 void USaveSubsystem::SetVisitedNodeIDs(const TArray<FName>& NewIDs)
 {
-    USaveGame_RunState* State = LoadRunState();
-    if (!State)
-    {
-        State = NewObject<USaveGame_RunState>();
-    }
+    USaveGame_RunState* State = GetOrCreateState();
     State->VisitedNodeIDs = NewIDs;
     SaveRunState(State);
 }
 
 void USaveSubsystem::SetRNGSeed(int32 Seed)
 {
-    USaveGame_RunState* State = LoadRunState();
-    if (!State)
-    {
-        State = NewObject<USaveGame_RunState>();
-    }
+    USaveGame_RunState* State = GetOrCreateState();
     State->RNGSeed = Seed;
     SaveRunState(State);
 }
 
 void USaveSubsystem::SetOwnedPatternIDs(const TArray<FName>& NewIDs)
 {
-    USaveGame_RunState* State = LoadRunState();
-    if (!State)
-    {
-        State = NewObject<USaveGame_RunState>();
-    }
+    USaveGame_RunState* State = GetOrCreateState();
     State->OwnedPatternIDs = NewIDs;
     SaveRunState(State);
 }
 
 void USaveSubsystem::SetMinionStatuses(const TMap<FName, FMinionStatusArray>& Statuses)
 {
-    USaveGame_RunState* State = LoadRunState();
-    if (!State)
-    {
-        State = NewObject<USaveGame_RunState>();
-    }
+    USaveGame_RunState* State = GetOrCreateState();
     State->MinionStatuses = Statuses;
     SaveRunState(State);
 }

--- a/Source/ExodusProtocol/Public/SaveSubsystem.h
+++ b/Source/ExodusProtocol/Public/SaveSubsystem.h
@@ -66,5 +66,7 @@ public:
 
 private:
     static const FString SlotName;
+    /** Load the save slot or create a new state if none exists. */
+    USaveGame_RunState* GetOrCreateState();
 };
 


### PR DESCRIPTION
## Summary
- create `GetOrCreateState` helper in SaveSubsystem
- simplify all state setters to use the helper

## Testing
- `clang++ -std=c++17 -c Source/ExodusProtocol/Private/SaveSubsystem.cpp` *(fails: 'SaveSubsystem.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d4884e81083269d890ccdfc44c3b9