### PR TITLE
Add CardVisualComponent for card animations

### DIFF
--- a/Source/ExodusProtocol/Private/CardActor.cpp
+++ b/Source/ExodusProtocol/Private/CardActor.cpp
@@ -7,6 +7,8 @@ ACardActor::ACardActor()
 
     RootComponent = CreateDefaultSubobject<USceneComponent>(TEXT("Root"));
     CardComponent = CreateDefaultSubobject<UCardComponent>(TEXT("CardComponent"));
+    CardVisual = CreateDefaultSubobject<UCardVisualComponent>(TEXT("CardVisual"));
+    CardVisual->SetupAttachment(RootComponent);
 }
 
 void ACardActor::MoveToZone(ECardZone NewZone)
@@ -27,10 +29,18 @@ void ACardActor::MoveToZone(ECardZone NewZone)
     if (OldZone == ECardZone::DrawPile && NewZone == ECardZone::Hand)
     {
         CardComponent->TriggerDraw();
+        if (CardVisual)
+        {
+            CardVisual->PlayIdle();
+        }
     }
     else if (OldZone == ECardZone::Hand && NewZone == ECardZone::Queue)
     {
         CardComponent->TriggerPlay();
+        if (CardVisual)
+        {
+            CardVisual->PlayAttack();
+        }
         if (UEventRouter* Router = UEventRouter::Get(this))
         {
             Router->OnCardPlayed.Broadcast(CardComponent->CardData);
@@ -42,6 +52,14 @@ void ACardActor::MoveToZone(ECardZone NewZone)
         if (OldZone == ECardZone::Queue)
         {
             CardComponent->TriggerResolve();
+            if (CardVisual)
+            {
+                CardVisual->PlayRetreat();
+            }
+        }
+        else if (CardVisual)
+        {
+            CardVisual->PlayRetreat();
         }
         CardComponent->TriggerDiscard();
     }

--- a/Source/ExodusProtocol/Private/CardVisualComponent.cpp
+++ b/Source/ExodusProtocol/Private/CardVisualComponent.cpp
@@ -1,0 +1,102 @@
+#include "CardVisualComponent.h"
+#include "CardComponent.h"
+#include "CardActor.h"
+#include "Components/SkeletalMeshComponent.h"
+#include "PaperFlipbookComponent.h"
+#include "PaperSpriteComponent.h"
+
+UCardVisualComponent::UCardVisualComponent()
+{
+    PrimaryComponentTick.bCanEverTick = false;
+}
+
+void UCardVisualComponent::BeginPlay()
+{
+    Super::BeginPlay();
+
+    if (ACardActor* OwnerCard = Cast<ACardActor>(GetOwner()))
+    {
+        if (OwnerCard->CardComponent)
+        {
+            VisualData = OwnerCard->CardComponent->CardData.Visual;
+        }
+    }
+
+    if (VisualData.SkeletalMesh)
+    {
+        SkeletalMeshComponent = NewObject<USkeletalMeshComponent>(GetOwner());
+        if (SkeletalMeshComponent)
+        {
+            SkeletalMeshComponent->SetupAttachment(this);
+            SkeletalMeshComponent->SetSkeletalMesh(VisualData.SkeletalMesh);
+            SkeletalMeshComponent->RegisterComponent();
+        }
+    }
+    else if (VisualData.Flipbook)
+    {
+        FlipbookComponent = NewObject<UPaperFlipbookComponent>(GetOwner());
+        if (FlipbookComponent)
+        {
+            FlipbookComponent->SetupAttachment(this);
+            FlipbookComponent->SetFlipbook(VisualData.Flipbook);
+            FlipbookComponent->RegisterComponent();
+        }
+    }
+    else if (VisualData.Sprite)
+    {
+        SpriteComponent = NewObject<UPaperSpriteComponent>(GetOwner());
+        if (SpriteComponent)
+        {
+            SpriteComponent->SetupAttachment(this);
+            SpriteComponent->SetSprite(VisualData.Sprite);
+            SpriteComponent->RegisterComponent();
+        }
+    }
+
+    PlayIdle();
+}
+
+void UCardVisualComponent::PlayAnimation(UAnimationAsset* Anim, bool bLoop)
+{
+    if (!Anim)
+    {
+        return;
+    }
+
+    if (SkeletalMeshComponent)
+    {
+        SkeletalMeshComponent->PlayAnimation(Anim, bLoop);
+    }
+    else if (FlipbookComponent)
+    {
+        if (UPaperFlipbook* Flip = Cast<UPaperFlipbook>(Anim))
+        {
+            FlipbookComponent->SetFlipbook(Flip);
+        }
+    }
+}
+
+void UCardVisualComponent::PlayIdle()
+{
+    PlayAnimation(VisualData.IdleAnimation, true);
+}
+
+void UCardVisualComponent::PlayAttack()
+{
+    PlayAnimation(VisualData.AttackAnimation, false);
+}
+
+void UCardVisualComponent::PlayDefend()
+{
+    PlayAnimation(VisualData.DefendAnimation, false);
+}
+
+void UCardVisualComponent::PlayWalk()
+{
+    PlayAnimation(VisualData.WalkAnimation, true);
+}
+
+void UCardVisualComponent::PlayRetreat()
+{
+    PlayAnimation(VisualData.RetreatAnimation, false);
+}

--- a/Source/ExodusProtocol/Public/CardActor.h
+++ b/Source/ExodusProtocol/Public/CardActor.h
@@ -3,6 +3,7 @@
 #include "CoreMinimal.h"
 #include "GameFramework/Actor.h"
 #include "CardComponent.h"
+#include "CardVisualComponent.h"
 #include "EventRouter.h"
 #include "CardActor.generated.h"
 
@@ -31,6 +32,10 @@ public:
     /** Component holding card data and events. */
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="Card")
     TObjectPtr<UCardComponent> CardComponent;
+
+    /** Handles visual asset and animations for this card. */
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="Card")
+    TObjectPtr<UCardVisualComponent> CardVisual;
 
     /** Move to a new zone and fire the relevant lifecycle events. */
     UFUNCTION(BlueprintCallable, Category="Card")

--- a/Source/ExodusProtocol/Public/CardVisualComponent.h
+++ b/Source/ExodusProtocol/Public/CardVisualComponent.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/SceneComponent.h"
+#include "CardTypes.h"
+#include "CardVisualComponent.generated.h"
+
+class USkeletalMeshComponent;
+class UPaperFlipbookComponent;
+class UPaperSpriteComponent;
+class ACardActor;
+
+/** Spawns visual assets for a card and plays animations. */
+UCLASS(ClassGroup=(Custom), meta=(BlueprintSpawnableComponent))
+class EXODUSPROTOCOL_API UCardVisualComponent : public USceneComponent
+{
+    GENERATED_BODY()
+public:
+    UCardVisualComponent();
+
+    /** Play idle animation. */
+    UFUNCTION(BlueprintCallable, Category="Card|Visual")
+    void PlayIdle();
+
+    /** Play attack animation. */
+    UFUNCTION(BlueprintCallable, Category="Card|Visual")
+    void PlayAttack();
+
+    /** Play defend animation. */
+    UFUNCTION(BlueprintCallable, Category="Card|Visual")
+    void PlayDefend();
+
+    /** Play walk animation. */
+    UFUNCTION(BlueprintCallable, Category="Card|Visual")
+    void PlayWalk();
+
+    /** Play retreat animation. */
+    UFUNCTION(BlueprintCallable, Category="Card|Visual")
+    void PlayRetreat();
+
+protected:
+    virtual void BeginPlay() override;
+
+private:
+    void PlayAnimation(UAnimationAsset* Anim, bool bLoop);
+
+    FCardVisualData VisualData;
+
+    UPROPERTY()
+    TObjectPtr<USkeletalMeshComponent> SkeletalMeshComponent = nullptr;
+
+    UPROPERTY()
+    TObjectPtr<UPaperFlipbookComponent> FlipbookComponent = nullptr;
+
+    UPROPERTY()
+    TObjectPtr<UPaperSpriteComponent> SpriteComponent = nullptr;
+};


### PR DESCRIPTION
## Summary
- implement `UCardVisualComponent` to spawn card visuals and play animations
- use the new component in `ACardActor` and trigger animations during zone changes

## Testing
- `npm --version`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d79c426e48326bb1757beb1c2c40d