### PR TITLE
Add visual hooks for card lifecycle

### DIFF
--- a/Source/ExodusProtocol/Private/CardActor.cpp
+++ b/Source/ExodusProtocol/Private/CardActor.cpp
@@ -11,6 +11,19 @@ ACardActor::ACardActor()
     CardVisual->SetupAttachment(RootComponent);
 }
 
+void ACardActor::BeginPlay()
+{
+    Super::BeginPlay();
+
+    if (CardComponent)
+    {
+        CardComponent->OnDraw.AddDynamic(this, &ACardActor::HandleDraw);
+        CardComponent->OnPlay.AddDynamic(this, &ACardActor::HandlePlay);
+        CardComponent->OnResolve.AddDynamic(this, &ACardActor::HandleResolve);
+        CardComponent->OnDiscard.AddDynamic(this, &ACardActor::HandleDiscard);
+    }
+}
+
 void ACardActor::MoveToZone(ECardZone NewZone)
 {
     if (CardZone == NewZone)
@@ -29,18 +42,10 @@ void ACardActor::MoveToZone(ECardZone NewZone)
     if (OldZone == ECardZone::DrawPile && NewZone == ECardZone::Hand)
     {
         CardComponent->TriggerDraw();
-        if (CardVisual)
-        {
-            CardVisual->PlayIdle();
-        }
     }
     else if (OldZone == ECardZone::Hand && NewZone == ECardZone::Queue)
     {
         CardComponent->TriggerPlay();
-        if (CardVisual)
-        {
-            CardVisual->PlayAttack();
-        }
         if (UEventRouter* Router = UEventRouter::Get(this))
         {
             Router->OnCardPlayed.Broadcast(CardComponent->CardData);
@@ -52,15 +57,80 @@ void ACardActor::MoveToZone(ECardZone NewZone)
         if (OldZone == ECardZone::Queue)
         {
             CardComponent->TriggerResolve();
-            if (CardVisual)
-            {
-                CardVisual->PlayRetreat();
-            }
-        }
-        else if (CardVisual)
-        {
-            CardVisual->PlayRetreat();
+            bResolvedBeforeDiscard = true;
         }
         CardComponent->TriggerDiscard();
+        bResolvedBeforeDiscard = false;
+    }
+}
+
+void ACardActor::HandleDraw()
+{
+    PlayIdle();
+    OnCardDrawn();
+}
+
+void ACardActor::HandlePlay()
+{
+    PlayAttack();
+    OnCardPlayed();
+}
+
+void ACardActor::HandleResolve()
+{
+    PlayRetreat();
+    OnCardResolved();
+}
+
+void ACardActor::HandleDiscard()
+{
+    if (!bResolvedBeforeDiscard)
+    {
+        PlayRetreat();
+    }
+    OnCardDiscarded();
+}
+
+void ACardActor::PlayAttack()
+{
+    if (CardVisual)
+    {
+        CardVisual->PlayAttack();
+    }
+    OnAttack();
+}
+
+void ACardActor::PlayDefend()
+{
+    if (CardVisual)
+    {
+        CardVisual->PlayDefend();
+    }
+    OnDefend();
+}
+
+void ACardActor::PlayWalk()
+{
+    if (CardVisual)
+    {
+        CardVisual->PlayWalk();
+    }
+    OnWalk();
+}
+
+void ACardActor::PlayRetreat()
+{
+    if (CardVisual)
+    {
+        CardVisual->PlayRetreat();
+    }
+    OnRetreat();
+}
+
+void ACardActor::PlayIdle()
+{
+    if (CardVisual)
+    {
+        CardVisual->PlayIdle();
     }
 }

--- a/Source/ExodusProtocol/Public/CardActor.h
+++ b/Source/ExodusProtocol/Public/CardActor.h
@@ -25,6 +25,8 @@ class EXODUSPROTOCOL_API ACardActor : public AActor
 public:
     ACardActor();
 
+    virtual void BeginPlay() override;
+
     /** Current lifecycle zone. */
     UPROPERTY(BlueprintReadOnly, Category="Card")
     ECardZone CardZone = ECardZone::DrawPile;
@@ -40,4 +42,71 @@ public:
     /** Move to a new zone and fire the relevant lifecycle events. */
     UFUNCTION(BlueprintCallable, Category="Card")
     void MoveToZone(ECardZone NewZone);
+
+    /** Called after the card is drawn into the player's hand. */
+    UFUNCTION(BlueprintImplementableEvent, Category="Card|Visual")
+    void OnCardDrawn();
+
+    /** Called when the card is played from the hand. */
+    UFUNCTION(BlueprintImplementableEvent, Category="Card|Visual")
+    void OnCardPlayed();
+
+    /** Called after the card's effect resolves. */
+    UFUNCTION(BlueprintImplementableEvent, Category="Card|Visual")
+    void OnCardResolved();
+
+    /** Called when the card is discarded or moved to the grave. */
+    UFUNCTION(BlueprintImplementableEvent, Category="Card|Visual")
+    void OnCardDiscarded();
+
+    /** Called whenever the attack animation is played. */
+    UFUNCTION(BlueprintImplementableEvent, Category="Card|Visual")
+    void OnAttack();
+
+    /** Called whenever the defend animation is played. */
+    UFUNCTION(BlueprintImplementableEvent, Category="Card|Visual")
+    void OnDefend();
+
+    /** Called whenever the walk animation is played. */
+    UFUNCTION(BlueprintImplementableEvent, Category="Card|Visual")
+    void OnWalk();
+
+    /** Called whenever the retreat animation is played. */
+    UFUNCTION(BlueprintImplementableEvent, Category="Card|Visual")
+    void OnRetreat();
+
+    /** Trigger attack animation and blueprint event. */
+    UFUNCTION(BlueprintCallable, Category="Card|Visual")
+    void PlayAttack();
+
+    /** Trigger defend animation and blueprint event. */
+    UFUNCTION(BlueprintCallable, Category="Card|Visual")
+    void PlayDefend();
+
+    /** Trigger walk animation and blueprint event. */
+    UFUNCTION(BlueprintCallable, Category="Card|Visual")
+    void PlayWalk();
+
+    /** Trigger retreat animation and blueprint event. */
+    UFUNCTION(BlueprintCallable, Category="Card|Visual")
+    void PlayRetreat();
+
+    /** Trigger idle animation and blueprint event. */
+    UFUNCTION(BlueprintCallable, Category="Card|Visual")
+    void PlayIdle();
+
+protected:
+    bool bResolvedBeforeDiscard = false;
+
+    UFUNCTION()
+    void HandleDraw();
+
+    UFUNCTION()
+    void HandlePlay();
+
+    UFUNCTION()
+    void HandleResolve();
+
+    UFUNCTION()
+    void HandleDiscard();
 };


### PR DESCRIPTION
## Summary
- trigger card visual animations from CardActor
- expose Blueprint events for card visual states

## Testing
- `clang++ -std=c++17 -fsyntax-only Source/ExodusProtocol/Private/CardActor.cpp -I Source/ExodusProtocol/Public` *(fails: 'CoreMinimal.h' not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d7c71921c83269ae285d124a44b43