### PR TITLE
Allow flipbook animations in card visuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 
 ## Visual Models & Animations
 
-The new `FCardVisualData` struct describes the presentation for any card‑spawned actor.  It holds optional fields for a sprite, flipbook or skeletal mesh plus five animation slots:
+The new `FCardVisualData` struct describes the presentation for any card‑spawned actor.  It holds optional fields for a sprite, flipbook or skeletal mesh plus five animation slots.  Each slot accepts either a `UAnimationAsset` or a `UPaperFlipbook`:
 
 * `IdleAnimation`
 * `AttackAnimation`

--- a/Source/ExodusProtocol/Private/CardVisualComponent.cpp
+++ b/Source/ExodusProtocol/Private/CardVisualComponent.cpp
@@ -56,7 +56,7 @@ void UCardVisualComponent::BeginPlay()
     PlayIdle();
 }
 
-void UCardVisualComponent::PlayAnimation(UAnimationAsset* Anim, bool bLoop)
+void UCardVisualComponent::PlayAnimation(UObject* Anim, bool bLoop)
 {
     if (!Anim)
     {
@@ -65,7 +65,10 @@ void UCardVisualComponent::PlayAnimation(UAnimationAsset* Anim, bool bLoop)
 
     if (SkeletalMeshComponent)
     {
-        SkeletalMeshComponent->PlayAnimation(Anim, bLoop);
+        if (UAnimationAsset* Animation = Cast<UAnimationAsset>(Anim))
+        {
+            SkeletalMeshComponent->PlayAnimation(Animation, bLoop);
+        }
     }
     else if (FlipbookComponent)
     {

--- a/Source/ExodusProtocol/Public/CardTypes.h
+++ b/Source/ExodusProtocol/Public/CardTypes.h
@@ -52,25 +52,25 @@ struct FCardVisualData : public FTableRowBase
     UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Card|Visual")
     TObjectPtr<USkeletalMesh> SkeletalMesh = nullptr;
 
-    /** Animation played while idle. */
+    /** Animation played while idle (flipbook or skeletal). */
     UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Card|Visual")
-    TObjectPtr<UAnimationAsset> IdleAnimation = nullptr;
+    TObjectPtr<UObject> IdleAnimation = nullptr;
 
-    /** Animation played when attacking. */
+    /** Animation played when attacking (flipbook or skeletal). */
     UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Card|Visual")
-    TObjectPtr<UAnimationAsset> AttackAnimation = nullptr;
+    TObjectPtr<UObject> AttackAnimation = nullptr;
 
-    /** Animation played while defending. */
+    /** Animation played while defending (flipbook or skeletal). */
     UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Card|Visual")
-    TObjectPtr<UAnimationAsset> DefendAnimation = nullptr;
+    TObjectPtr<UObject> DefendAnimation = nullptr;
 
-    /** Animation used for walking or movement. */
+    /** Animation used for walking or movement (flipbook or skeletal). */
     UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Card|Visual")
-    TObjectPtr<UAnimationAsset> WalkAnimation = nullptr;
+    TObjectPtr<UObject> WalkAnimation = nullptr;
 
-    /** Animation used for retreat or death. */
+    /** Animation used for retreat or death (flipbook or skeletal). */
     UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category="Card|Visual")
-    TObjectPtr<UAnimationAsset> RetreatAnimation = nullptr;
+    TObjectPtr<UObject> RetreatAnimation = nullptr;
 };
 
 

--- a/Source/ExodusProtocol/Public/CardVisualComponent.h
+++ b/Source/ExodusProtocol/Public/CardVisualComponent.h
@@ -42,7 +42,7 @@ protected:
     virtual void BeginPlay() override;
 
 private:
-    void PlayAnimation(UAnimationAsset* Anim, bool bLoop);
+    void PlayAnimation(UObject* Anim, bool bLoop);
 
     FCardVisualData VisualData;
 


### PR DESCRIPTION
## Summary
- allow the animation fields of `FCardVisualData` to hold either a flipbook or a skeletal animation
- update `UCardVisualComponent` to cast from a generic `UObject` and play the appropriate animation type
- document the flexible animation slots in the README

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_686eac39e09c8326b07ad7ea43d7f657